### PR TITLE
Workout structure clarity: all structure types overhauled

### DIFF
--- a/docs/specs/Clear_-_Structure_Types_Spec.md
+++ b/docs/specs/Clear_-_Structure_Types_Spec.md
@@ -172,6 +172,7 @@ Rep schemes modify how reps are prescribed *within* any structure. They're ortho
 | `pyramid` | Up then down | 3-6-9-12-9-6-3 | Peak in middle |
 | `inverse` | Two movements, opposite direction | 10/1, 9/2, 8/3... 1/10 | Paired exercises |
 | `n_plus_one` | Add 1 each round until failure | 1, 2, 3, 4... | "Death by" format |
+| `ladder_fixed_interval` | Ladder on primary, fixed reps of secondary between rungs | Push-ups: 2-4-6-8, 4 burpees between | Interval exercise marked `is_interval_exercise: true` |
 
 **Where rep schemes apply:**
 

--- a/docs/specs/Clear_-_Workout_Generation_Prompt_v2.md
+++ b/docs/specs/Clear_-_Workout_Generation_Prompt_v2.md
@@ -77,6 +77,7 @@ Rep schemes are modifiers that apply within structures. They go in the `reps` fi
 - pyramid: Up then down — "3-6-9-12-9-6-3"
 - inverse: Paired movements, opposite direction — "10/1, 9/2, 8/3..."
 - n_plus_one: Add 1 each round until failure — "1, 2, 3, 4..."
+- ladder_fixed_interval: Ladder on primary movement, fixed reps of a secondary between each rung — "Push-ups: 2-4-6-8-10-8-6-4-2, with 4 burpees between each set". Mark the interval exercise with `"is_interval_exercise": true`.
 
 Ladders work well in For Time and Circuit structures. N+1 pairs well with EMOM and AMRAP.
 

--- a/src/components/workout/ActiveExerciseCard.tsx
+++ b/src/components/workout/ActiveExerciseCard.tsx
@@ -13,25 +13,54 @@ interface ActiveExerciseCardProps {
     sectionType?: string;
     /** Render without Card wrapper (for use inside structure cards like Superset/Circuit) */
     bare?: boolean;
+    /** EMOM: 'active' highlights this exercise, 'inactive' dims it */
+    emomState?: 'active' | 'inactive';
+    /** EMOM minute assignment label (e.g. "ODD MIN", "EVEN MIN") */
+    minuteLabel?: string | null;
+    /** Pair/sequence label shown before exercise name (e.g. "A1", "A2", "1.", "2.") */
+    pairLabel?: string | null;
+    /** Hide reps from summary line (ladder sections show reps once at section level) */
+    hideReps?: boolean;
+    /** Start with the expanded detail area open */
+    defaultExpanded?: boolean;
     className?: string;
 }
 
 const HIDE_INPUTS_SECTIONS = ['warmup', 'cooldown', 'mobility'];
+
+/** Check if a rest value is meaningful (non-zero, non-empty) */
+const hasRest = (rest?: string): boolean => {
+    if (!rest) return false;
+    const cleaned = rest.toLowerCase().replace(/\s/g, '');
+    return cleaned !== '0s' && cleaned !== '0' && cleaned !== '';
+};
+
+/** Format sets×reps into compact prescription */
+const formatPrescription = (sets: number | null, reps: string): string => {
+    if (sets) return `${sets}×${reps}`;
+    return `${reps} reps`;
+};
 
 export const ActiveExerciseCard = ({
     exercise,
     onLog,
     sectionType,
     bare = false,
+    emomState,
+    minuteLabel,
+    pairLabel,
+    hideReps = false,
+    defaultExpanded = false,
     className
 }: ActiveExerciseCardProps) => {
-    const [isExpanded, setIsExpanded] = useState(false);
+    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
     const [weight, setWeight] = useState(exercise.weight_logged || "");
     const [reps, setReps] = useState(exercise.reps || "");
     const [note, setNote] = useState("");
 
     const showInputs = !sectionType || !HIDE_INPUTS_SECTIONS.includes(sectionType);
-    const isBodyweight = !exercise.equipment || exercise.equipment.toLowerCase() === 'bodyweight';
+    const WEIGHTED_EQUIPMENT = ['barbell', 'dumbbell', 'dumbbells', 'kettlebell', 'cable', 'machine', 'ez bar', 'trap bar', 'smith machine', 'plate'];
+    const hasWeight = exercise.equipment && WEIGHTED_EQUIPMENT.includes(exercise.equipment.toLowerCase());
 
     const handleWeightChange = (v: string) => {
         setWeight(v);
@@ -48,33 +77,61 @@ export const ActiveExerciseCard = ({
         onLog(exercise.id, { notes: v });
     };
 
+    const isEmomActive = emomState === 'active';
+    const isEmomInactive = emomState === 'inactive';
+
     const Wrapper = bare ? 'div' : Card;
     const wrapperProps = bare
-        ? { className: cn("overflow-hidden", className) }
-        : { padding: "none" as const, className: cn("overflow-hidden", className) };
+        ? { className: cn("overflow-hidden transition-opacity duration-200", isEmomInactive && "opacity-40", className) }
+        : { padding: "none" as const, className: cn("overflow-hidden transition-opacity duration-200", isEmomInactive && "opacity-40", className) };
 
     return (
         <Wrapper {...wrapperProps}>
+            {/* EMOM active accent bar */}
+            {isEmomActive && (
+                <div
+                    className="h-0.5"
+                    style={{ backgroundColor: 'var(--border-cta-primary)' }}
+                />
+            )}
             {/* Header - Always visible (glanceable) */}
             <button
                 onClick={() => setIsExpanded(!isExpanded)}
-                className="w-full p-4 flex items-start gap-3 text-left"
+                className={cn("w-full flex items-start gap-3 text-left", bare ? "py-2 px-4" : "p-4")}
             >
                 <div className="flex-1 min-w-0 space-y-1">
-                    <h3
-                        className="text-heading-h6 font-bold leading-tight uppercase"
-                        style={{ color: 'var(--text-header)' }}
-                    >
-                        {exercise.name}
-                    </h3>
+                    <div className="flex items-center justify-between gap-2">
+                        <h3
+                            className="text-heading-h6 font-bold leading-tight uppercase"
+                            style={{ color: isEmomInactive ? 'var(--text-disabled)' : 'var(--text-header)' }}
+                        >
+                            {pairLabel && (
+                                <span
+                                    className="text-label-xs font-bold uppercase tracking-widest mr-2"
+                                    style={{ color: 'var(--text-header)' }}
+                                >
+                                    {pairLabel}
+                                </span>
+                            )}
+                            {exercise.name}
+                        </h3>
+                        {minuteLabel && (
+                            <span
+                                className="text-label-xs uppercase tracking-wider shrink-0"
+                                style={{ color: 'var(--text-paragraph)' }}
+                            >
+                                {minuteLabel}
+                            </span>
+                        )}
+                    </div>
+                    {/* Compact prescription */}
                     <div
                         className="text-paragraph-sm flex flex-wrap gap-x-3 gap-y-1"
                         style={{ color: 'var(--text-paragraph)' }}
                     >
-                        {exercise.sets && <span>{exercise.sets} sets</span>}
-                        <span>{exercise.reps} reps</span>
-                        {exercise.tempo && <span>Tempo: {exercise.tempo}</span>}
-                        {exercise.rest && <span>Rest: {exercise.rest}</span>}
+                        {!hideReps && (
+                            <span>{formatPrescription(exercise.sets, exercise.reps)}</span>
+                        )}
                     </div>
                 </div>
                 <span className="p-1 shrink-0" style={{ color: 'var(--icon-cta)' }}>
@@ -84,7 +141,18 @@ export const ActiveExerciseCard = ({
 
             {/* Expanded Area */}
             {isExpanded && (
-                <div className="px-4 pb-4 space-y-3">
+                <div className={cn("px-4 space-y-3", bare ? "pb-2" : "pb-4")}>
+                    {/* Tempo & Rest details */}
+                    {(exercise.tempo || hasRest(exercise.rest)) && (
+                        <div
+                            className="text-paragraph-sm flex flex-wrap gap-x-3 gap-y-1"
+                            style={{ color: 'var(--text-paragraph)' }}
+                        >
+                            {exercise.tempo && <span>Tempo: {exercise.tempo}</span>}
+                            {hasRest(exercise.rest) && <span>Rest: {exercise.rest}</span>}
+                        </div>
+                    )}
+
                     {/* Coaching Cues */}
                     {exercise.coachingCues && (
                         <p
@@ -101,10 +169,7 @@ export const ActiveExerciseCard = ({
                     {(exercise.regression || exercise.progression) && (
                         <div
                             className="text-paragraph-sm space-y-1 pt-2"
-                            style={{
-                                borderTop: '2px solid var(--border-spacer)',
-                                color: 'var(--text-paragraph)',
-                            }}
+                            style={{ color: 'var(--text-paragraph)' }}
                         >
                             {exercise.regression && (
                                 <p><span style={{ color: 'var(--text-disabled)' }}>Easier:</span> {exercise.regression}</p>
@@ -117,8 +182,8 @@ export const ActiveExerciseCard = ({
 
                     {/* Weight / Reps Inputs */}
                     {showInputs && (
-                        <div className={isBodyweight ? "" : "grid grid-cols-2 gap-3"}>
-                            {!isBodyweight && (
+                        <div className={hasWeight ? "grid grid-cols-2 gap-3" : ""}>
+                            {hasWeight && (
                                 <div className="space-y-1.5">
                                     <label
                                         className="text-label-xs uppercase tracking-wider"

--- a/src/components/workout/LadderRungs.tsx
+++ b/src/components/workout/LadderRungs.tsx
@@ -1,0 +1,105 @@
+import { ChamferedFrame } from "@/components/ChamferedFrame";
+
+interface LadderRungsProps {
+    rungs: number[];
+    /** 'text' = plain numbers (during workout), 'interactive' = chamfered frames (cap reached) */
+    mode?: 'text' | 'interactive';
+    selectedRung?: number | null;
+    onSelect?: (rungIndex: number) => void;
+}
+
+export const LadderRungs = ({
+    rungs,
+    mode = 'text',
+    selectedRung = null,
+    onSelect,
+}: LadderRungsProps) => {
+    // Mode A: plain text numbers — no containers
+    if (mode === 'text') {
+        return (
+            <div className="flex gap-3 flex-wrap">
+                {rungs.map((reps, i) => (
+                    <span
+                        key={i}
+                        className="text-paragraph-md font-mono font-bold"
+                        style={{ color: 'var(--text-paragraph)' }}
+                    >
+                        {reps}
+                    </span>
+                ))}
+            </div>
+        );
+    }
+
+    // Mode B: interactive chamfered frames
+    const getState = (index: number): 'default' | 'completed' | 'selected' => {
+        if (selectedRung === null) return 'default';
+        if (index === selectedRung) return 'selected';
+        if (index < selectedRung) return 'completed';
+        return 'default';
+    };
+
+    const tokenMap = {
+        default: {
+            surface: 'var(--surface-radio-unselect)',
+            border: 'var(--border-radio-unselected)',
+            text: 'var(--text-radio-text-unselected)',
+        },
+        completed: {
+            surface: 'var(--surface-radio-selected)',
+            border: 'var(--border-radio-select)',
+            text: 'var(--text-radio-text-select)',
+        },
+        selected: {
+            surface: 'var(--surface-radio-selected)',
+            border: 'var(--border-radio-select)',
+            text: 'var(--text-radio-text-select)',
+        },
+    };
+
+    return (
+        <div className="overflow-x-auto -mx-4 px-4">
+            <div className="flex gap-1" style={{ minWidth: 'min-content' }}>
+                {rungs.map((reps, i) => {
+                    const state = getState(i);
+                    const tokens = tokenMap[state];
+
+                    return (
+                        <button
+                            key={i}
+                            onClick={() => onSelect?.(i)}
+                            className="min-w-[32px] min-h-[44px] flex items-center justify-center"
+                            style={{ WebkitTapHighlightColor: 'transparent' }}
+                        >
+                            <ChamferedFrame
+                                cornerSize="sm"
+                                surfaceColor={tokens.surface}
+                                borderColor={tokens.border}
+                                hasLeftBorder={true}
+                            >
+                                <div className="px-2 py-1.5 flex items-center justify-center min-w-[32px] h-[36px]">
+                                    <span
+                                        className="text-paragraph-sm font-mono font-bold"
+                                        style={{ color: tokens.text }}
+                                    >
+                                        {reps}
+                                    </span>
+                                </div>
+                            </ChamferedFrame>
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+/** Parse a rep string like "2-4-6-8-6-4-2 each" into rung numbers */
+export const parseRungs = (reps: string): number[] =>
+    reps.split('-').map(s => parseInt(s, 10)).filter(n => !isNaN(n));
+
+/** Check if a rep scheme string indicates a ladder pattern */
+export const isLadderReps = (reps: string): boolean => {
+    const rungs = parseRungs(reps);
+    return rungs.length >= 3;
+};

--- a/src/components/workout/ProgressTracker.tsx
+++ b/src/components/workout/ProgressTracker.tsx
@@ -17,10 +17,9 @@ export function ProgressTracker({ progress, className }: ProgressTrackerProps) {
         <div
             className={cn("w-full", className)}
             style={{
-                height: '4px',
-                border: '1px solid var(--border-slider)',
-                padding: '2px',
-                boxSizing: 'content-box',
+                height: '10px',
+                border: '2px solid var(--border-slider)',
+                padding: '1px',
             }}
         >
             <div

--- a/src/components/workout/SectionRenderer.tsx
+++ b/src/components/workout/SectionRenderer.tsx
@@ -1,19 +1,355 @@
+import { useState, useCallback, useEffect } from "react";
+import { Minus, Plus } from "lucide-react";
 import { WorkoutSection, Exercise } from "@/types/workout";
 import { ActiveExerciseCard } from "./ActiveExerciseCard";
 import { SupersetCard, CircuitCard } from "./StructureCards";
-import { SectionTimer } from "./SectionTimer";
+import { SectionTimer, TimerState } from "./SectionTimer";
+import { LadderRungs, parseRungs, isLadderReps } from "./LadderRungs";
 import { Card } from "../Card";
+import { ChamferedFrame } from "../ChamferedFrame";
+import { ExerciseNotes } from "./ExerciseNotes";
+
+export interface StructureResultData {
+    structure_type: string;
+    rounds_completed?: number;
+    completion_time_seconds?: number;
+    completed_under_cap?: boolean;
+    rep_scheme?: string;
+    highest_rung?: number | null;
+    notes?: string | null;
+}
 
 interface SectionRendererProps {
     section: WorkoutSection;
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
+    /** Called when a timed section completes with structure-level result data */
+    onStructureResult?: (sectionName: string, data: StructureResultData) => void;
 }
 
 const TIMED_TYPES = ['emom', 'amrap', 'for_time'];
 
+/** Helper: generate EMOM minute assignment label for an exercise */
+function getEmomMinuteLabel(exerciseIndex: number, totalExercises: number): string | null {
+    if (totalExercises <= 1) return null;
+    if (totalExercises === 2) {
+        return exerciseIndex === 0 ? 'ODD MIN' : 'EVEN MIN';
+    }
+    // 3+ exercises: show the minute pattern
+    const minutes: number[] = [];
+    for (let m = exerciseIndex + 1; m <= 20; m += totalExercises) {
+        minutes.push(m);
+        if (minutes.length >= 3) break;
+    }
+    return `MIN ${minutes.join(', ')}…`;
+}
+
+/** Timed section (EMOM/AMRAP/For Time) rendered as a single card */
+const TimedSectionContent = ({
+    section,
+    firstStructure,
+    onLog,
+    onStructureResult,
+}: {
+    section: WorkoutSection;
+    firstStructure: NonNullable<Exercise['structure']>;
+    onLog: SectionRendererProps['onLog'];
+    onStructureResult?: SectionRendererProps['onStructureResult'];
+}) => {
+    const [currentMinute, setCurrentMinute] = useState(0);
+    const [timerState, setTimerState] = useState<TimerState>('idle');
+    const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+    // AMRAP completion state
+    const [roundsCompleted, setRoundsCompleted] = useState(0);
+    const [partialNote, setPartialNote] = useState('');
+
+    // Ladder state
+    const [selectedRung, setSelectedRung] = useState<number | null>(null);
+    const [finishedEarly, setFinishedEarly] = useState(false);
+
+    const isEmom = firstStructure.type === 'emom';
+    const isAmrap = firstStructure.type === 'amrap';
+    const isForTime = firstStructure.type === 'for_time';
+    const isComplete = timerState === 'complete';
+    const exerciseCount = section.exercises.length;
+
+    // Ladder detection: check if first exercise reps look like a ladder pattern
+    const firstReps = section.exercises[0]?.reps || '';
+    const isLadder = isForTime && isLadderReps(firstReps);
+    const ladderRungs = isLadder ? parseRungs(firstReps) : [];
+    // Extract the rep pattern string (before any " each" suffix)
+    const ladderPattern = isLadder ? firstReps.replace(/\s*each.*$/i, '').trim() : '';
+
+    // Report AMRAP results to parent when data changes
+    useEffect(() => {
+        if (isAmrap && isComplete && onStructureResult) {
+            onStructureResult(section.name, {
+                structure_type: 'amrap',
+                rounds_completed: roundsCompleted,
+                completion_time_seconds: elapsedSeconds,
+                notes: partialNote || null,
+            });
+        }
+    }, [isAmrap, isComplete, roundsCompleted, elapsedSeconds, partialNote, onStructureResult, section.name]);
+
+    // Report ladder For Time results to parent
+    useEffect(() => {
+        if (isLadder && isComplete && onStructureResult) {
+            onStructureResult(section.name, {
+                structure_type: 'for_time',
+                completion_time_seconds: elapsedSeconds,
+                completed_under_cap: finishedEarly,
+                rep_scheme: ladderPattern,
+                highest_rung: finishedEarly ? null : (selectedRung ?? null),
+            });
+        }
+    }, [isLadder, isComplete, elapsedSeconds, finishedEarly, selectedRung, ladderPattern, onStructureResult, section.name]);
+
+    const timerMode = firstStructure.type === 'for_time' ? 'countup' as const : 'countdown' as const;
+    const initialSeconds = (firstStructure.type === 'emom' || firstStructure.type === 'amrap')
+        ? (firstStructure.minutes || 0) * 60
+        : (firstStructure.type === 'for_time' ? (firstStructure.time_cap_mins || 0) * 60 : 0);
+
+    const timerLabel = firstStructure.type?.replace('_', ' ') || '';
+
+    const handleMinuteChange = useCallback((minute: number) => {
+        setCurrentMinute(minute);
+    }, []);
+
+    const handleTimerStateChange = useCallback((state: TimerState) => {
+        setTimerState(state);
+    }, []);
+
+    const handleFinish = useCallback((elapsed: number) => {
+        setElapsedSeconds(elapsed);
+        // For ladder: if elapsed < cap, user finished early (completed the ladder)
+        if (isLadder && initialSeconds > 0 && elapsed < initialSeconds) {
+            setFinishedEarly(true);
+            setSelectedRung(ladderRungs.length - 1); // All rungs completed
+        }
+    }, [isLadder, initialSeconds, ladderRungs.length]);
+
+    // EMOM: determine which exercise is active based on current minute
+    const activeExerciseIndex = isEmom && currentMinute > 0 && exerciseCount > 1
+        ? (currentMinute - 1) % exerciseCount
+        : -1;
+
+    const formatTime = (totalSeconds: number) => {
+        const m = Math.floor(totalSeconds / 60);
+        const s = totalSeconds % 60;
+        return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+    };
+
+    return (
+        <Card cornerSize="md" padding="none">
+            {/* Label */}
+            <div className="px-4 pt-3 pb-1">
+                <span
+                    className="text-label-xs font-bold uppercase tracking-widest"
+                    style={{ color: 'var(--text-card-label)' }}
+                >
+                    {isAmrap && isComplete ? `${section.type.replace('_', ' ')} \u2022 AMRAP Complete`
+                        : isLadder && isComplete && finishedEarly ? `${section.type.replace('_', ' ')} \u2022 Complete`
+                        : isLadder && isComplete ? `${section.type.replace('_', ' ')} \u2022 Cap Reached`
+                        : `${section.type.replace('_', ' ')} \u2022 ${timerLabel}`}
+                </span>
+            </div>
+
+            {/* Timer + controls */}
+            <div className="px-4 py-3">
+                <SectionTimer
+                    mode={timerMode}
+                    initialSeconds={initialSeconds}
+                    emom={isEmom}
+                    onMinuteChange={isEmom ? handleMinuteChange : undefined}
+                    onStateChange={handleTimerStateChange}
+                    onFinish={handleFinish}
+                    hideControls={(isAmrap && isComplete) || (isLadder && isComplete)}
+                />
+            </div>
+
+            {/* Ladder: cap reached — interactive rung selector (Path B only) */}
+            {isLadder && isComplete && !finishedEarly && (
+                <div className="px-4 pb-3 space-y-3">
+                    <span
+                        className="text-label-xs font-bold uppercase tracking-widest block text-center"
+                        style={{ color: 'var(--text-header)' }}
+                    >
+                        How far did you get?
+                    </span>
+                    <LadderRungs
+                        rungs={ladderRungs}
+                        mode="interactive"
+                        selectedRung={selectedRung}
+                        onSelect={setSelectedRung}
+                    />
+                </div>
+            )}
+
+            {/* Ladder: rep scheme label + plain text rungs (during workout / after early finish) */}
+            {isLadder && (finishedEarly || !isComplete) && (
+                <div className="px-4 pb-2 space-y-2">
+                    <div className="flex items-baseline gap-2">
+                        <span
+                            className="text-label-xs font-bold uppercase tracking-widest"
+                            style={{ color: 'var(--text-card-label)' }}
+                        >
+                            Ladder:
+                        </span>
+                        {firstStructure.type === 'for_time' && !isComplete && (
+                            <span
+                                className="text-label-xs uppercase tracking-widest"
+                                style={{ color: 'var(--text-paragraph)', opacity: 0.6 }}
+                            >
+                                {firstStructure.time_cap_mins} min cap
+                            </span>
+                        )}
+                    </div>
+                    <LadderRungs rungs={ladderRungs} mode="text" />
+                </div>
+            )}
+
+            {/* AMRAP completion UI */}
+            {isAmrap && isComplete && (
+                <div className="px-4 pb-4 space-y-4">
+                    {/* Elapsed time confirmation */}
+                    <div className="text-center">
+                        <span
+                            className="text-time-lg font-bold font-mono opacity-60"
+                            style={{ color: 'var(--text-timer)' }}
+                        >
+                            {formatTime(elapsedSeconds)} ✓
+                        </span>
+                    </div>
+
+                    {/* Rounds stepper */}
+                    <div className="space-y-2">
+                        <span
+                            className="text-label-xs font-bold uppercase tracking-widest block text-center"
+                            style={{ color: 'var(--text-header)' }}
+                        >
+                            Rounds Completed
+                        </span>
+                        <div className="flex items-center justify-center gap-4">
+                            <button
+                                onClick={() => setRoundsCompleted(prev => Math.max(0, prev - 1))}
+                                className="min-w-[48px] min-h-[48px] flex items-center justify-center"
+                            >
+                                <ChamferedFrame
+                                    cornerSize="sm"
+                                    surfaceColor="var(--surface-cta-secondary)"
+                                    borderColor="var(--border-cta-secondary)"
+                                >
+                                    <div className="px-3 py-2">
+                                        <Minus size={24} style={{ color: 'var(--text-cta)' }} />
+                                    </div>
+                                </ChamferedFrame>
+                            </button>
+
+                            <span
+                                className="text-time-xl font-bold font-mono min-w-[60px] text-center"
+                                style={{ color: 'var(--text-timer)' }}
+                            >
+                                {roundsCompleted}
+                            </span>
+
+                            <button
+                                onClick={() => setRoundsCompleted(prev => prev + 1)}
+                                className="min-w-[48px] min-h-[48px] flex items-center justify-center"
+                            >
+                                <ChamferedFrame
+                                    cornerSize="sm"
+                                    surfaceColor="var(--surface-cta-primary)"
+                                    borderColor="var(--border-cta-primary)"
+                                >
+                                    <div className="px-3 py-2">
+                                        <Plus size={24} style={{ color: 'var(--text-cta)' }} />
+                                    </div>
+                                </ChamferedFrame>
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Partial round notes */}
+                    <ExerciseNotes
+                        note={partialNote}
+                        onSave={setPartialNote}
+                    />
+                </div>
+            )}
+
+            {/* AMRAP "each round" label for multi-exercise sections */}
+            {isAmrap && exerciseCount >= 2 && (
+                <div className="px-4 mt-3 -mb-1">
+                    <span
+                        className="text-label-xs font-bold uppercase tracking-widest"
+                        style={{ color: 'var(--text-card-label)' }}
+                    >
+                        Each Round:
+                    </span>
+                </div>
+            )}
+
+            {/* Ladder "each rung" label for multi-exercise sections */}
+            {isLadder && exerciseCount >= 2 && (
+                <div className="px-4 mt-2 -mb-1">
+                    <span
+                        className="text-label-xs font-bold uppercase tracking-widest"
+                        style={{ color: 'var(--text-card-label)' }}
+                    >
+                        Each Rung:
+                    </span>
+                </div>
+            )}
+
+            {/* Exercises */}
+            <div className="pb-3 space-y-1">
+                {section.exercises.map((exercise, i) => {
+                    // Interval exercises render as annotations, not full cards
+                    if (exercise.is_interval_exercise) {
+                        return (
+                            <div key={exercise.id} className="px-4 -mt-2 pb-2">
+                                <span
+                                    className="text-paragraph-sm italic"
+                                    style={{ color: 'var(--text-paragraph)' }}
+                                >
+                                    {exercise.reps} {exercise.name} between each set
+                                </span>
+                            </div>
+                        );
+                    }
+
+                    // EMOM highlighting: active vs inactive
+                    const emomState = isEmom && exerciseCount > 1 && currentMinute > 0
+                        ? (i === activeExerciseIndex ? 'active' : 'inactive')
+                        : undefined;
+
+                    const minuteLabel = isEmom
+                        ? getEmomMinuteLabel(i, exerciseCount)
+                        : null;
+
+                    return (
+                        <ActiveExerciseCard
+                            key={exercise.id}
+                            exercise={exercise}
+                            onLog={onLog}
+                            sectionType={section.type}
+                            bare
+                            emomState={emomState}
+                            minuteLabel={minuteLabel}
+                            hideReps={isLadder}
+                        />
+                    );
+                })}
+            </div>
+        </Card>
+    );
+};
+
 export const SectionRenderer = ({
     section,
     onLog,
+    onStructureResult,
 }: SectionRendererProps) => {
 
     const groupExercises = (exercises: Exercise[]) => {
@@ -69,40 +405,42 @@ export const SectionRenderer = ({
 
     // Timed sections: everything in one card
     if (isTimedSection) {
-        const timerMode = firstStructure?.type === 'for_time' ? 'countup' as const : 'countdown' as const;
-        const initialSeconds = (firstStructure?.type === 'emom' || firstStructure?.type === 'amrap')
-            ? (firstStructure.minutes || 0) * 60
-            : (firstStructure?.type === 'for_time' ? (firstStructure.time_cap_mins || 0) * 60 : 0);
+        return (
+            <TimedSectionContent
+                section={section}
+                firstStructure={firstStructure!}
+                onLog={onLog}
+                onStructureResult={onStructureResult}
+            />
+        );
+    }
 
-        const timerLabel = firstStructure?.type?.replace('_', ' ') || '';
+    // Ladder detection for non-timed sections (standard, circuit, accessory, core)
+    const firstReps = section.exercises[0]?.reps || '';
+    const sectionHasLadder = isLadderReps(firstReps);
+    const sectionRungs = sectionHasLadder ? parseRungs(firstReps) : [];
+    const exerciseCount = section.exercises.length;
 
+    // Warmup/Mobility/Cooldown: all exercises in one card
+    const WRAP_ALL_SECTIONS = ['warmup', 'cooldown', 'mobility'];
+    const wrapAll = WRAP_ALL_SECTIONS.includes(section.type);
+
+    if (wrapAll) {
         return (
             <Card cornerSize="md" padding="none">
-                {/* Label */}
-                <div className="px-4 pt-3 pb-1">
+                <div className="px-4 pt-3 pb-2">
                     <span
                         className="text-label-xs font-bold uppercase tracking-widest"
                         style={{ color: 'var(--text-card-label)' }}
                     >
-                        {timerLabel}
+                        {section.type.replace('_', ' ')}
                     </span>
                 </div>
-
-                {/* Timer + controls */}
-                <div className="px-4 py-3">
-                    <SectionTimer
-                        mode={timerMode}
-                        initialSeconds={initialSeconds}
-                        emom={firstStructure?.type === 'emom'}
-                    />
-                </div>
-
-                {/* Exercises */}
-                <div>
+                <div className="pb-3">
                     {section.exercises.map((exercise, i) => (
                         <div key={exercise.id}>
                             {i > 0 && (
-                                <div className="mx-4" style={{ borderTop: '2px solid var(--border-spacer)' }} />
+                                <div className="mx-4 my-1" style={{ borderTop: '2px solid var(--border-spacer)' }} />
                             )}
                             <ActiveExerciseCard
                                 exercise={exercise}
@@ -117,44 +455,115 @@ export const SectionRenderer = ({
         );
     }
 
-    // Non-timed sections: standard layout
+    // Non-timed sections: standard layout with section labels
+    // Collect standalone exercises to wrap them in a single section card
+    const standaloneExercises = groups.filter(item => !('type' in item) || (item.type !== 'superset' && item.type !== 'circuit')) as Exercise[];
+    const structureGroups = groups.filter(item => 'type' in item && (item.type === 'superset' || item.type === 'circuit'));
+
     return (
         <div className="space-y-4">
-            {groups.map((item, idx) => {
-                if ('type' in item && (item.type === 'superset' || item.type === 'circuit')) {
-                    if (item.type === 'superset') {
-                        return (
-                            <SupersetCard
-                                key={`group-${idx}`}
-                                exercises={item.exercises}
+            {/* Ladder header for non-timed sections */}
+            {sectionHasLadder && (
+                <Card cornerSize="md" padding="none">
+                    <div className="px-4 pt-3 pb-2 space-y-2">
+                        <div className="flex items-baseline gap-2">
+                            <span
+                                className="text-label-xs font-bold uppercase tracking-widest"
+                                style={{ color: 'var(--text-card-label)' }}
+                            >
+                                {section.type.replace('_', ' ')} &bull; Ladder:
+                            </span>
+                        </div>
+                        <LadderRungs rungs={sectionRungs} mode="text" />
+                        {exerciseCount >= 2 && (
+                            <div className="mt-2">
+                                <span
+                                    className="text-label-xs font-bold uppercase tracking-widest"
+                                    style={{ color: 'var(--text-card-label)' }}
+                                >
+                                    Each Rung:
+                                </span>
+                            </div>
+                        )}
+                    </div>
+                    <div className="pb-3">
+                        {section.exercises.map((exercise) => (
+                            <ActiveExerciseCard
+                                key={exercise.id}
+                                exercise={exercise}
                                 onLog={onLog}
                                 sectionType={section.type}
-                                structure={item.structure}
+                                bare
+                                hideReps
+                                defaultExpanded={section.exercises.length === 1}
                             />
-                        );
-                    } else {
-                        return (
-                            <CircuitCard
-                                key={`group-${idx}`}
-                                exercises={item.exercises}
-                                onLog={onLog}
-                                sectionType={section.type}
-                                structure={item.structure}
-                            />
-                        );
-                    }
-                } else {
-                    const ex = item as Exercise;
-                    return (
-                        <ActiveExerciseCard
-                            key={ex.id}
-                            exercise={ex}
-                            onLog={onLog}
-                            sectionType={section.type}
-                        />
-                    );
-                }
-            })}
+                        ))}
+                    </div>
+                </Card>
+            )}
+
+            {/* Non-ladder content */}
+            {!sectionHasLadder && (
+                <>
+                    {/* Structure groups (superset, circuit) with section prefix */}
+                    {structureGroups.map((item, idx) => {
+                        const group = item as { type: 'superset' | 'circuit'; exercises: Exercise[]; structure: any };
+                        if (group.type === 'superset') {
+                            return (
+                                <SupersetCard
+                                    key={`group-${idx}`}
+                                    exercises={group.exercises}
+                                    onLog={onLog}
+                                    sectionType={section.type}
+                                    sectionName={section.type.replace('_', ' ')}
+                                    structure={group.structure}
+                                />
+                            );
+                        } else {
+                            return (
+                                <CircuitCard
+                                    key={`group-${idx}`}
+                                    exercises={group.exercises}
+                                    onLog={onLog}
+                                    sectionType={section.type}
+                                    sectionName={section.type.replace('_', ' ')}
+                                    structure={group.structure}
+                                />
+                            );
+                        }
+                    })}
+
+                    {/* Standalone exercises wrapped in a section card */}
+                    {standaloneExercises.length > 0 && (
+                        <Card cornerSize="md" padding="none">
+                            <div className="px-4 pt-3 pb-1">
+                                <span
+                                    className="text-label-xs font-bold uppercase tracking-widest"
+                                    style={{ color: 'var(--text-card-label)' }}
+                                >
+                                    {section.type.replace('_', ' ')}
+                                </span>
+                            </div>
+                            <div className="pb-3">
+                                {standaloneExercises.map((ex, i) => (
+                                    <div key={ex.id}>
+                                        {i > 0 && (
+                                            <div className="mx-4" style={{ borderTop: '2px solid var(--border-spacer)' }} />
+                                        )}
+                                        <ActiveExerciseCard
+                                            exercise={ex}
+                                            onLog={onLog}
+                                            sectionType={section.type}
+                                            bare
+                                            defaultExpanded={standaloneExercises.length === 1}
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        </Card>
+                    )}
+                </>
+            )}
         </div>
     );
 };

--- a/src/components/workout/SectionTimer.tsx
+++ b/src/components/workout/SectionTimer.tsx
@@ -5,32 +5,62 @@ import { CTAButton } from "../CTAButton";
 interface SectionTimerProps {
     mode: 'countdown' | 'countup';
     initialSeconds?: number;
-    onFinish?: (remainingSeconds: number) => void;
+    /** Called when timer completes or user taps Finish. Receives elapsed seconds. */
+    onFinish?: (elapsedSeconds: number) => void;
+    /** Called on each state change so parent can react to completion */
+    onStateChange?: (state: TimerState) => void;
     /** EMOM uses per-minute low-time warning instead of overall */
     emom?: boolean;
+    /** Called each second with current minute (1-based) for EMOM sections */
+    onMinuteChange?: (currentMinute: number) => void;
+    /** Hide controls (when parent renders custom completion UI) */
+    hideControls?: boolean;
     className?: string;
 }
 
-type TimerState = 'idle' | 'running' | 'paused' | 'complete';
+export type TimerState = 'idle' | 'running' | 'paused' | 'complete';
 
 export const SectionTimer = ({
     mode,
     initialSeconds = 0,
     onFinish,
+    onStateChange,
     emom = false,
+    onMinuteChange,
+    hideControls = false,
     className
 }: SectionTimerProps) => {
     const [seconds, setSeconds] = useState(mode === 'countdown' ? initialSeconds : 0);
     const [timerState, setTimerState] = useState<TimerState>('idle');
 
-    // EMOM: low-time triggers in the last 10s of each minute
-    // Others: low-time triggers in the last 10s overall
+    const totalMinutes = emom ? Math.floor(initialSeconds / 60) : 0;
+
+    // For EMOM countdown: elapsed = initial - remaining, currentMinute is 1-based
+    const currentMinute = emom && timerState !== 'idle'
+        ? Math.min(Math.floor((initialSeconds - seconds) / 60) + 1, totalMinutes)
+        : 0;
+
+    // Timer color shift: green → error tokens as a "wrap it up" warning.
+    // EMOM: triggers in the last 10s of each minute, resets on new minute.
+    // Non-EMOM (AMRAP): triggers in the last 10s overall.
     const isLowTime = timerState === 'running' && mode === 'countdown' && seconds > 0 && (
         emom
             ? (seconds % 60 > 0 && seconds % 60 <= 10)
             : seconds <= 10
     );
     const isComplete = timerState === 'complete';
+
+    const updateState = useCallback((newState: TimerState) => {
+        setTimerState(newState);
+        onStateChange?.(newState);
+    }, [onStateChange]);
+
+    // Notify parent of minute changes for EMOM active exercise highlighting
+    useEffect(() => {
+        if (emom && currentMinute > 0 && onMinuteChange) {
+            onMinuteChange(currentMinute);
+        }
+    }, [emom, currentMinute, onMinuteChange]);
 
     useEffect(() => {
         if (timerState !== 'running') return;
@@ -39,26 +69,36 @@ export const SectionTimer = ({
             setSeconds((prev) => {
                 if (mode === 'countdown') {
                     if (prev <= 1) {
-                        setTimerState('complete');
+                        updateState('complete');
+                        onFinish?.(initialSeconds);
                         return 0;
                     }
                     return prev - 1;
                 }
-                return prev + 1;
+                // Countup: auto-complete at cap if set
+                const next = prev + 1;
+                if (initialSeconds > 0 && next >= initialSeconds) {
+                    updateState('complete');
+                    onFinish?.(initialSeconds);
+                    return initialSeconds;
+                }
+                return next;
             });
         }, 1000);
 
         return () => clearInterval(interval);
-    }, [timerState, mode]);
+    }, [timerState, mode, updateState, onFinish, initialSeconds]);
 
-    const handleStart = () => setTimerState('running');
-    const handlePause = () => setTimerState('paused');
-    const handleResume = () => setTimerState('running');
+    const handleStart = () => updateState('running');
+    const handlePause = () => updateState('paused');
+    const handleResume = () => updateState('running');
 
     const handleFinish = useCallback(() => {
-        setTimerState('complete');
-        onFinish?.(seconds);
-    }, [seconds, onFinish]);
+        updateState('complete');
+        // Report elapsed time: for countdown, elapsed = initial - remaining
+        const elapsed = mode === 'countdown' ? initialSeconds - seconds : seconds;
+        onFinish?.(elapsed);
+    }, [seconds, initialSeconds, mode, onFinish, updateState]);
 
     const formatTime = (totalSeconds: number) => {
         const m = Math.floor(totalSeconds / 60);
@@ -95,6 +135,15 @@ export const SectionTimer = ({
                     >
                         {formatTime(seconds)}
                     </span>
+                    {/* EMOM minute indicator */}
+                    {emom && timerState !== 'idle' && !isComplete && (
+                        <span
+                            className="text-label-sm font-mono font-bold uppercase tracking-wider mt-1"
+                            style={{ color: textColor, transition: 'color 1s ease' }}
+                        >
+                            MIN {currentMinute} OF {totalMinutes}
+                        </span>
+                    )}
                     {isComplete && (
                         <span
                             className="text-label-xs font-bold uppercase"
@@ -106,8 +155,8 @@ export const SectionTimer = ({
                 </div>
             </ChamferedFrame>
 
-            {/* Controls */}
-            <div className="flex gap-3 mt-3">
+            {/* Controls — hidden when parent renders custom completion UI */}
+            {!hideControls && <div className="flex gap-3 mt-3">
                 {timerState === 'idle' && (
                     <CTAButton onClick={handleStart} size="md" fullWidth>
                         Start
@@ -116,10 +165,10 @@ export const SectionTimer = ({
 
                 {timerState === 'running' && (
                     <>
-                        <CTAButton onClick={handlePause} size="md" fullWidth>
+                        <CTAButton onClick={handlePause} variant="secondary" size="md" fullWidth>
                             Pause
                         </CTAButton>
-                        <CTAButton onClick={handleFinish} variant="secondary" size="md" fullWidth>
+                        <CTAButton onClick={handleFinish} size="md" fullWidth>
                             Finish
                         </CTAButton>
                     </>
@@ -127,15 +176,15 @@ export const SectionTimer = ({
 
                 {timerState === 'paused' && (
                     <>
-                        <CTAButton onClick={handleResume} size="md" fullWidth>
+                        <CTAButton onClick={handleResume} variant="secondary" size="md" fullWidth>
                             Resume
                         </CTAButton>
-                        <CTAButton onClick={handleFinish} variant="secondary" size="md" fullWidth>
+                        <CTAButton onClick={handleFinish} size="md" fullWidth>
                             Finish
                         </CTAButton>
                     </>
                 )}
-            </div>
+            </div>}
         </div>
     );
 };

--- a/src/components/workout/StructureCards.tsx
+++ b/src/components/workout/StructureCards.tsx
@@ -6,10 +6,22 @@ interface StructureCardProps {
     exercises: Exercise[];
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
     sectionType?: string;
+    sectionName?: string;
     structure: ExerciseStructure;
 }
 
+/** Check if a rest value is meaningful (non-zero, non-empty) */
+const hasRest = (rest?: string): boolean => {
+    if (!rest) return false;
+    const cleaned = rest.toLowerCase().replace(/\s/g, '');
+    return cleaned !== '0s' && cleaned !== '0' && cleaned !== '';
+};
+
 export const SupersetCard = ({ exercises, onLog, sectionType }: StructureCardProps) => {
+    // Get the shared rest from the last exercise
+    const lastExercise = exercises[exercises.length - 1];
+    const pairRest = hasRest(lastExercise?.rest) ? lastExercise.rest : null;
+
     return (
         <Card
             cornerSize="md"
@@ -20,24 +32,40 @@ export const SupersetCard = ({ exercises, onLog, sectionType }: StructureCardPro
                     className="text-label-xs font-bold uppercase tracking-widest"
                     style={{ color: 'var(--text-card-label)' }}
                 >
-                    Superset
+                    {sectionType ? `${sectionType.replace('_', ' ')} \u2022 Superset` : 'Superset'}
                 </span>
             </div>
-            <div>
-                {exercises.map((exercise, i) => (
-                    <div key={exercise.id}>
-                        {i > 0 && (
-                            <div className="mx-4" style={{ borderTop: '2px solid var(--border-spacer)' }} />
-                        )}
+            {/* Vertical connector + exercises */}
+            <div className="flex ml-4">
+                {/* Connector line — trimmed to align with exercise text */}
+                <div
+                    className="w-0.5 my-3 shrink-0"
+                    style={{ backgroundColor: 'var(--text-header)' }}
+                />
+                <div className="pl-2 flex-1 min-w-0 pb-3">
+                    {exercises.map((exercise, i) => (
                         <ActiveExerciseCard
+                            key={exercise.id}
                             exercise={exercise}
                             onLog={onLog}
                             sectionType={sectionType}
                             bare
+                            pairLabel={`A${i + 1}`}
                         />
-                    </div>
-                ))}
+                    ))}
+                </div>
             </div>
+            {/* Consolidated rest after pair */}
+            {pairRest && (
+                <div className="px-4 pb-3 pt-1">
+                    <span
+                        className="text-label-xs uppercase tracking-widest"
+                        style={{ color: 'var(--text-paragraph)' }}
+                    >
+                        Rest: {pairRest} after both
+                    </span>
+                </div>
+            )}
         </Card>
     );
 };
@@ -45,6 +73,10 @@ export const SupersetCard = ({ exercises, onLog, sectionType }: StructureCardPro
 export const CircuitCard = ({ exercises, onLog, sectionType, structure }: StructureCardProps) => {
     const rounds = 'rounds' in structure ? structure.rounds : undefined;
 
+    // Get round rest from the last exercise
+    const lastExercise = exercises[exercises.length - 1];
+    const roundRest = hasRest(lastExercise?.rest) ? lastExercise.rest : null;
+
     return (
         <Card
             cornerSize="md"
@@ -55,24 +87,48 @@ export const CircuitCard = ({ exercises, onLog, sectionType, structure }: Struct
                     className="text-label-xs font-bold uppercase tracking-widest"
                     style={{ color: 'var(--text-card-label)' }}
                 >
-                    {rounds ? `Circuit · ${rounds} Rounds` : 'Circuit'}
+                    {sectionType
+                        ? `${sectionType.replace('_', ' ')} \u2022 ${rounds ? `Circuit \u2022 ${rounds} Rounds` : 'Circuit'}`
+                        : rounds ? `Circuit \u2022 ${rounds} Rounds` : 'Circuit'}
                 </span>
             </div>
-            <div>
+
+            {/* EACH ROUND label */}
+            {exercises.length >= 2 && (
+                <div className="px-4 mt-1 -mb-1">
+                    <span
+                        className="text-label-xs font-bold uppercase tracking-widest"
+                        style={{ color: 'var(--text-card-label)' }}
+                    >
+                        Each Round:
+                    </span>
+                </div>
+            )}
+
+            <div className="pb-3 space-y-1">
                 {exercises.map((exercise, i) => (
-                    <div key={exercise.id}>
-                        {i > 0 && (
-                            <div className="mx-4" style={{ borderTop: '2px solid var(--border-spacer)' }} />
-                        )}
-                        <ActiveExerciseCard
-                            exercise={exercise}
-                            onLog={onLog}
-                            sectionType={sectionType}
-                            bare
-                        />
-                    </div>
+                    <ActiveExerciseCard
+                        key={exercise.id}
+                        exercise={exercise}
+                        onLog={onLog}
+                        sectionType={sectionType}
+                        bare
+                        pairLabel={`${i + 1}.`}
+                    />
                 ))}
             </div>
+
+            {/* Consolidated round rest */}
+            {roundRest && (
+                <div className="px-4 pb-3 pt-1">
+                    <span
+                        className="text-label-xs uppercase tracking-widest"
+                        style={{ color: 'var(--text-paragraph)' }}
+                    >
+                        {roundRest} rest between rounds
+                    </span>
+                </div>
+            )}
         </Card>
     );
 };

--- a/src/pages/WorkoutScreen.tsx
+++ b/src/pages/WorkoutScreen.tsx
@@ -1,8 +1,8 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
 import { GeneratedWorkout } from "@/types/workout";
 import { WorkoutNavigation } from "@/components/workout/WorkoutNavigation";
 import { GlobalTimer } from "@/components/workout/GlobalTimer";
-import { SectionRenderer } from "@/components/workout/SectionRenderer";
+import { SectionRenderer, StructureResultData } from "@/components/workout/SectionRenderer";
 import { ProgressTracker } from "@/components/workout/ProgressTracker";
 
 interface WorkoutScreenProps {
@@ -14,6 +14,7 @@ interface WorkoutScreenProps {
 export const WorkoutScreen = ({ workout, onExit, onFinish }: WorkoutScreenProps) => {
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const [loggedData, setLoggedData] = useState<Record<string, any>>({});
+  const [structureResults, setStructureResults] = useState<Record<string, StructureResultData>>({});
 
   const touchStartX = useRef<number | null>(null);
   const startTime = useRef(Date.now());
@@ -53,6 +54,7 @@ export const WorkoutScreen = ({ workout, onExit, onFinish }: WorkoutScreenProps)
     if (isLastSection) {
       onFinish({
         loggedData,
+        structureResults,
         durationSeconds: Math.floor((Date.now() - startTime.current) / 1000)
       });
     } else {
@@ -68,6 +70,10 @@ export const WorkoutScreen = ({ workout, onExit, onFinish }: WorkoutScreenProps)
     }));
   };
 
+  const handleStructureResult = useCallback((sectionName: string, data: StructureResultData) => {
+    setStructureResults(prev => ({ ...prev, [sectionName]: data }));
+  }, []);
+
   return (
     <div
       className="min-h-screen grain-overlay flex flex-col pb-28 relative"
@@ -79,20 +85,13 @@ export const WorkoutScreen = ({ workout, onExit, onFinish }: WorkoutScreenProps)
       <div className="max-w-md mx-auto w-full px-4 pt-2">
         {/* Section Header */}
         <div className="mb-6 space-y-2">
-          <h1
-            className="text-heading-h3 font-bold uppercase tracking-wider break-words"
-            style={{ color: 'var(--text-header)' }}
-          >
-            {currentSection.name}
-          </h1>
           <ProgressTracker progress={progress} />
-          <div
-            className="flex justify-between text-label-xs uppercase tracking-widest"
+          <span
+            className="text-label-xs uppercase tracking-widest"
             style={{ color: 'var(--text-paragraph)' }}
           >
-            <span>Section {currentSectionIndex + 1} of {workout.sections.length}</span>
-            <span>{currentSection.type.replace('_', ' ')}</span>
-          </div>
+            {workout.anchor} &bull; Intensity {workout.intensity}
+          </span>
         </div>
 
         {/* Exercises */}
@@ -100,6 +99,7 @@ export const WorkoutScreen = ({ workout, onExit, onFinish }: WorkoutScreenProps)
           key={currentSectionIndex}
           section={currentSection}
           onLog={handleLog}
+          onStructureResult={handleStructureResult}
         />
       </div>
 

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -151,6 +151,7 @@ export interface Exercise {
   progression?: string;
   equipment?: string;
   structure?: ExerciseStructure;
+  is_interval_exercise?: boolean;
   weight_logged?: string; // User input
 }
 

--- a/supabase/functions/generate-workout/index.ts
+++ b/supabase/functions/generate-workout/index.ts
@@ -137,6 +137,7 @@ Rep schemes are modifiers that apply within structures. They go in the \`reps\` 
 - pyramid: Up then down — "3-6-9-12-9-6-3"
 - inverse: Paired movements, opposite direction — "10/1, 9/2, 8/3..."
 - n_plus_one: Add 1 each round until failure — "1, 2, 3, 4..."
+- ladder_fixed_interval: Ladder on primary movement, fixed reps of a secondary between each rung — "Push-ups: 2-4-6-8-10-8-6-4-2, with 4 burpees between each set". Mark the interval exercise with \`"is_interval_exercise": true\`.
 
 Ladders work well in For Time and Circuit structures. N+1 pairs well with EMOM and AMRAP.
 


### PR DESCRIPTION
## Summary
- **EMOM**: Minute tracking with active/inactive exercise highlighting, ODD/EVEN MIN labels
- **AMRAP**: Round stepper completion UI, "Each Round:" label for multi-exercise sections
- **Ladder (For Time)**: Rung detection from rep patterns, plain text + interactive display modes, two completion paths (finished early vs cap reached), cross-structure support
- **Superset**: A1/A2 pairing labels, vertical connector line, consolidated rest ("Rest: 90s after both")
- **Circuit**: Numbered exercises (1. 2. 3.), "Each Round:" label, consolidated rest, dividers removed
- **All cards**: Compact collapsed state (sets×reps), tempo/rest to expanded only, weighted equipment whitelist, Rest:0s suppression, consistent top/bottom padding
- **Layout**: Removed h1 section heading, card labels show "TYPE • MODIFIER", warmup/mobility/cooldown wrapped in single card, standalone exercises in card with section label
- **Timer**: Countup auto-complete at cap, minute indicator color matches warning state
- **Progress bar**: 2px border weight to match card borders, border-box sizing fix

## Test plan
- [ ] Superset shows A1/A2 labels, vertical connector, consolidated rest, compact collapsed state
- [ ] Circuit shows numbered exercises, EACH ROUND label, single rest line, no dividers
- [ ] EMOM highlights active exercise, shows minute labels, timer tracks minutes
- [ ] AMRAP shows round stepper on completion, EACH ROUND label
- [ ] Ladder detects rep patterns, shows plain text during workout, interactive on cap reached
- [ ] All cards: bottom padding matches top visually, no Rest:0s anywhere
- [ ] Progress bar aligns with card width, 2px border
- [ ] Expanding exercises shows full detail (tempo, cues, weight, rest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)