### PR TITLE
Generation screen: Duration & Notes redesign

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 **Project:** Clear App (5-3-1 Workout Generator)
-**Last Updated:** 2026-02-26
+**Last Updated:** 2026-02-27
 
 ---
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-02-26
+**Last Session:** 2026-02-27
 
 ---
 
@@ -13,14 +13,54 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** Workout UX
-**Current Task:** Structure clarity complete
-**Last Completed:** Workout structure clarity — all structure types overhauled
+**Current Phase:** Generation Screen UX
+**Current Task:** Duration & Notes redesign complete
+**Last Completed:** Generation screen Duration/Notes card wrapping, radio presets, label consistency
 **Blocking Issues:** Superset connector horizontal spacing needs fine-tuning (cosmetic)
 
 ---
 
 ## Session Entries
+
+### Session: 2026-02-27 - Generation Screen Duration & Notes Redesign
+
+**Duration:** ~30 min
+**Mode:** Claude Code
+**Branch:** `feature/generation-screen-duration-notes-redesign` → PR #3
+
+#### What Got Done
+- **DurationSelector**: Rewrote Duration from plain Input into Card-wrapped radio button presets (15/30/45/60) with full-width Custom button on second row
+- **NotesField**: Wrapped Textarea in Card with card-label styled heading
+- **Custom duration validation**: Numbers-only input (strips non-digits), 5–120 range validation on blur with toast, generate button disabled until valid value entered
+- **Default duration**: Set to 45 min on screen load
+- **Label consistency**: Updated Intensity Level, Focus Area, Location labels from `--text-paragraph` to `--text-card-label` color token across all generation screen sections
+- **Code review**: Caught redundant `font-bold` (already in `.text-label-xs` utility), removed from all labels
+
+#### What Came Up (Unexpected)
+- RadioButton row of 5 overflowed card on mobile — "CUSTOM" text at 14px bold couldn't fit in equal-width flex distribution. Fixed by moving Custom to its own full-width row below the 4 presets.
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| 4 presets in row + Custom stacked below | 5 equal-width RadioButtons overflow on mobile; stacking Custom gives it full width |
+| Generate blocked when custom selected without valid value | User requirement — empty custom duration shouldn't allow workout generation |
+| Numbers-only input with digit stripping | Prevents invalid input at keystroke level rather than just on blur |
+| No `font-bold` on labels | `.text-label-xs` already includes `font-weight: 700` — redundant class |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `src/components/OptionalFields.tsx` | Rewritten — DurationSelector + NotesField sub-components with Card wrapping |
+| `src/pages/GenerationScreen.tsx` | Modified — default time "45", canGenerate requires time !== "" |
+| `src/components/IntensitySlider.tsx` | Modified — label color to --text-card-label |
+| `src/components/AnchorGrid.tsx` | Modified — label color to --text-card-label |
+| `src/components/LocationAccordion.tsx` | Modified — label color to --text-card-label |
+
+#### Status
+- TypeScript compiles clean, build passes
+- PR #3 created, ready for merge
+
+---
 
 ### Session: 2026-02-26 - Workout Structure Clarity
 

--- a/src/components/AnchorGrid.tsx
+++ b/src/components/AnchorGrid.tsx
@@ -24,7 +24,7 @@ export const AnchorGrid = ({ selected, onSelect }: AnchorGridProps) => {
     <Card cornerSize="md" padding="md">
       <label
         className="text-label-xs uppercase tracking-widest mb-4 block"
-        style={{ color: "var(--text-paragraph)" }}
+        style={{ color: "var(--text-card-label)" }}
       >
         Focus Area
       </label>

--- a/src/components/IntensitySlider.tsx
+++ b/src/components/IntensitySlider.tsx
@@ -14,7 +14,7 @@ export const IntensitySlider = ({ value, onChange }: IntensitySliderProps) => {
     <Card cornerSize="md" padding="lg">
       <label
         className="text-label-xs uppercase tracking-widest mb-4 block"
-        style={{ color: "var(--text-paragraph)" }}
+        style={{ color: "var(--text-card-label)" }}
       >
         Intensity Level
       </label>

--- a/src/components/LocationAccordion.tsx
+++ b/src/components/LocationAccordion.tsx
@@ -26,7 +26,7 @@ export const LocationAccordion = ({ selected, onSelect, locations }: LocationAcc
         <div>
           <span
             className="text-label-xs uppercase tracking-widest block mb-1"
-            style={{ color: "var(--text-paragraph)" }}
+            style={{ color: "var(--text-card-label)" }}
           >
             Location
           </span>

--- a/src/components/OptionalFields.tsx
+++ b/src/components/OptionalFields.tsx
@@ -1,5 +1,115 @@
+import { useState } from "react";
 import { Input } from "./ui/input";
 import { Textarea } from "./ui/textarea";
+import { Card } from "./Card";
+import { RadioButton } from "./RadioButton";
+import { toast } from "./ui/sonner";
+
+const DURATION_PRESETS = ["15", "30", "45", "60"] as const;
+type DurationOption = (typeof DURATION_PRESETS)[number] | "custom";
+
+interface DurationSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function DurationSelector({ value, onChange }: DurationSelectorProps) {
+  const isPreset = DURATION_PRESETS.includes(value as typeof DURATION_PRESETS[number]);
+  const [selectedOption, setSelectedOption] = useState<DurationOption>(
+    isPreset ? (value as typeof DURATION_PRESETS[number]) : value ? "custom" : "45"
+  );
+  const [customValue, setCustomValue] = useState(isPreset ? "" : value);
+
+  const handlePresetClick = (preset: typeof DURATION_PRESETS[number]) => {
+    setSelectedOption(preset);
+    onChange(preset);
+  };
+
+  const handleCustomClick = () => {
+    setSelectedOption("custom");
+    onChange(customValue || "");
+  };
+
+  const handleCustomBlur = () => {
+    const parsed = parseInt(customValue, 10);
+    if (isNaN(parsed) || parsed < 5 || parsed > 120) {
+      toast.info("Duration must be between 5 and 120 minutes");
+      return;
+    }
+    onChange(String(parsed));
+  };
+
+  return (
+    <Card cornerSize="md" padding="md">
+      <label
+        className="text-label-xs uppercase tracking-widest mb-3 block"
+        style={{ color: "var(--text-card-label)" }}
+      >
+        Duration
+      </label>
+
+      <div className="flex gap-2">
+        {DURATION_PRESETS.map((preset) => (
+          <RadioButton
+            key={preset}
+            selected={selectedOption === preset}
+            onClick={() => handlePresetClick(preset)}
+            label={preset}
+            className="flex-1"
+          />
+        ))}
+      </div>
+      <RadioButton
+        selected={selectedOption === "custom"}
+        onClick={handleCustomClick}
+        label="Custom"
+        className="w-full mt-2"
+      />
+
+      {selectedOption === "custom" && (
+        <div className="mt-3">
+          <Input
+            type="text"
+            inputMode="numeric"
+            value={customValue}
+            onChange={(e) => {
+              const digits = e.target.value.replace(/\D/g, "");
+              setCustomValue(digits);
+              const parsed = parseInt(digits, 10);
+              onChange(parsed >= 5 && parsed <= 120 ? digits : "");
+            }}
+            onBlur={handleCustomBlur}
+            placeholder="Minutes (5–120)"
+          />
+        </div>
+      )}
+    </Card>
+  );
+}
+
+interface NotesFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function NotesField({ value, onChange }: NotesFieldProps) {
+  return (
+    <Card cornerSize="md" padding="md">
+      <label
+        className="text-label-xs uppercase tracking-widest mb-3 block"
+        style={{ color: "var(--text-card-label)" }}
+      >
+        Notes
+      </label>
+      <Textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Any notes or modifications..."
+        className="min-h-[85px]"
+      />
+    </Card>
+  );
+}
 
 interface OptionalFieldsProps {
   time: string;
@@ -16,28 +126,8 @@ export const OptionalFields = ({
 }: OptionalFieldsProps) => {
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
-        <label className="block text-paragraph-sm text-foreground">
-          Duration
-        </label>
-        <Input
-          value={time}
-          onChange={(e) => onTimeChange(e.target.value)}
-          placeholder="45 min"
-        />
-      </div>
-
-      <div className="space-y-2">
-        <label className="block text-paragraph-sm text-foreground">
-          Notes
-        </label>
-        <Textarea
-          value={notes}
-          onChange={(e) => onNotesChange(e.target.value)}
-          placeholder="Any notes or modifications..."
-          className="min-h-[85px]"
-        />
-      </div>
+      <DurationSelector value={time} onChange={onTimeChange} />
+      <NotesField value={notes} onChange={onNotesChange} />
     </div>
   );
 };

--- a/src/pages/GenerationScreen.tsx
+++ b/src/pages/GenerationScreen.tsx
@@ -30,7 +30,7 @@ export const GenerationScreen = ({ onGenerate, userPreferences, isGenerating = f
   const [intensity, setIntensity] = useState(7);
   const [anchor, setAnchor] = useState<AnchorType | null>(null);
   const [location, setLocation] = useState(defaultLocation?.name || "Gym");
-  const [time, setTime] = useState("");
+  const [time, setTime] = useState("45");
   const [notes, setNotes] = useState("");
 
 
@@ -44,7 +44,7 @@ export const GenerationScreen = ({ onGenerate, userPreferences, isGenerating = f
     });
   };
 
-  const canGenerate = anchor !== null;
+  const canGenerate = anchor !== null && time !== "";
 
   return (
     <div className="min-h-screen grain-overlay">


### PR DESCRIPTION
## Summary
- Rewrite `OptionalFields` into `DurationSelector` (Card-wrapped radio presets 15/30/45/60 + full-width Custom button) and `NotesField` (Card-wrapped textarea)
- Default duration to 45 min; block workout generation when Custom is selected without a valid 5–120 minute value
- Unify all generation screen section labels (Intensity, Focus Area, Location, Duration, Notes) to `--text-card-label` color token

## Test plan
- [ ] Generation screen loads with 45 pre-selected in duration row
- [ ] Clicking a preset (15/30/45/60) updates duration immediately
- [ ] Clicking Custom reveals numeric input; generate button disabled until valid value entered
- [ ] Custom input rejects non-numeric characters
- [ ] Values outside 5–120 show toast on blur and keep generate disabled
- [ ] All section labels use consistent card-label styling
- [ ] Notes field wrapped in Card matches other sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)