### PR TITLE
Session awareness hook + auto-branching in /execute

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -187,6 +187,7 @@ Hooks run automatically before/after tool calls. Configured in `.claude/settings
 
 | Hook | Event | What It Does |
 |------|-------|--------------|
+| `session-start-check.sh` | SessionStart | Warns about in-progress work (dirty files, unpushed branches, stashes) |
 | `git-safety-check.sh` | PreToolUse (Bash) | Blocks direct pushes/merges to main |
 
 ### What Gets Blocked
@@ -270,6 +271,7 @@ debug.md → [fix] → token-check.md (if UI) → pr-workflow.md
 │   └── todo.md
 │
 ├── hooks/
+│   ├── session-start-check.sh  ← Session start awareness
 │   └── git-safety-check.sh
 │
 ├── plans/

--- a/.claude/commands/execute.md
+++ b/.claude/commands/execute.md
@@ -15,6 +15,7 @@ Execute a session plan from `.claude/plans/`.
 
 4. **Follow the skill steps:**
    - Load the plan and parse structure
+   - Create a working branch (`feature/[plan-name]`) or confirm existing branch
    - Read all context files
    - Map tasks to relevant skills
    - Initialize TodoWrite with all tasks

--- a/.claude/hooks/session-start-check.sh
+++ b/.claude/hooks/session-start-check.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Session Start Hook - Detects in-progress work across the repo
+# Outputs a summary to stdout so Claude can relay it to the user.
+# If nothing is found, outputs nothing (clean start).
+
+set -e
+
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+OUTPUT=""
+
+# --- Check current branch and uncommitted changes ---
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+DIRTY_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "$BRANCH" != "main" ] || [ "$DIRTY_COUNT" -gt 0 ]; then
+  if [ "$BRANCH" != "main" ]; then
+    OUTPUT+="Current branch: $BRANCH"$'\n'
+  fi
+  if [ "$DIRTY_COUNT" -gt 0 ]; then
+    OUTPUT+="  - $DIRTY_COUNT uncommitted file(s)"$'\n'
+  fi
+fi
+
+# --- Check feature branches with unpushed commits ---
+UNPUSHED=""
+for branch in $(git for-each-ref --format='%(refname:short)' refs/heads/feature/ 2>/dev/null); do
+  upstream=$(git rev-parse --abbrev-ref "$branch@{upstream}" 2>/dev/null) || continue
+  ahead=$(git rev-list --count "$upstream..$branch" 2>/dev/null) || continue
+  if [ "$ahead" -gt 0 ]; then
+    UNPUSHED+="  - $branch ($ahead unpushed commit(s))"$'\n'
+  fi
+done
+
+if [ -n "$UNPUSHED" ]; then
+  OUTPUT+=$'\n'"Branches with unpushed work:"$'\n'
+  OUTPUT+="$UNPUSHED"
+fi
+
+# --- Check stashed changes ---
+STASH_COUNT=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
+if [ "$STASH_COUNT" -gt 0 ]; then
+  OUTPUT+=$'\n'"Stashed changes: $STASH_COUNT stash(es)"$'\n'
+fi
+
+# --- Output if anything was found ---
+if [ -n "$OUTPUT" ]; then
+  echo "IN-PROGRESS WORK DETECTED:"
+  echo ""
+  echo "$OUTPUT"
+  echo "Remind the user about this before starting new work."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-check.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.claude/skills/execute-plan.md
+++ b/.claude/skills/execute-plan.md
@@ -36,7 +36,31 @@ This skill takes a session plan and executes it task-by-task, loading relevant s
   - `## Context` — Files to read before starting
   - `## Tasks` — Work items with Do/Acceptance sections
 
-### 2. Load Context Files
+### 2. Create Working Branch
+
+Before loading context, ensure work happens on an isolated feature branch.
+
+1. **Derive branch name from plan filename:**
+   - `SESSION_PLAN_auth_refactor.md` → `feature/auth-refactor`
+   - Rule: drop `SESSION_PLAN_` prefix, replace underscores with hyphens, prepend `feature/`
+
+2. **Check current branch:**
+   - **On `main`:** Create and checkout the new branch from main
+     ```
+     git checkout -b feature/[derived-name]
+     ```
+   - **Already on the target branch:** Continue (resuming a prior session)
+   - **On a different feature branch:** Ask the user:
+     ```
+     You're currently on [current-branch]. Options:
+     1. Stay on this branch (work here instead)
+     2. Stash changes and switch to feature/[derived-name]
+     3. Abort — sort out branches manually
+     ```
+
+3. **Check working tree:** If there are uncommitted changes, warn the user and ask whether to stash, commit, or continue anyway.
+
+### 3. Load Context Files
 
 - Read every file listed in the plan's `## Context` section
 - Look for patterns like:
@@ -45,7 +69,7 @@ This skill takes a session plan and executes it task-by-task, loading relevant s
   - Any file paths mentioned
 - Build understanding before starting any work
 
-### 3. Map Tasks to Skills
+### 4. Map Tasks to Skills
 
 For each task, detect type keywords and load relevant skills:
 
@@ -61,7 +85,7 @@ Also check:
 - If task explicitly names a skill via `**Skill:**` field, load that
 - Consult `.claude/README.md` trigger table for additional mappings
 
-### 4. Initialize Progress Tracking
+### 5. Initialize Progress Tracking
 
 Use TodoWrite to create items for each task:
 
@@ -75,7 +99,7 @@ TodoWrite([
 
 All tasks start as `pending`.
 
-### 5. Execute Tasks Sequentially
+### 6. Execute Tasks Sequentially
 
 For each task:
 
@@ -85,7 +109,7 @@ For each task:
 4. **Execute the work** — Make the changes, create files, etc.
 5. **Check `**Acceptance:**` criteria** — Validate each criterion
 
-### 6. Validate Acceptance Criteria
+### 7. Validate Acceptance Criteria
 
 For each criterion in the task's `**Acceptance:**` section:
 
@@ -114,7 +138,7 @@ Options:
 - If skip: Note the skip, continue to next criterion/task
 - If pause: Save state, user can run `/execute` again to resume
 
-### 7. Complete Task
+### 8. Complete Task
 
 - Only mark `completed` in TodoWrite when:
   - ALL acceptance criteria pass, OR
@@ -122,7 +146,7 @@ Options:
 
 - Move to next task
 
-### 8. Close Session
+### 9. Close Session
 
 After all tasks complete:
 
@@ -179,6 +203,7 @@ After completion:
 
 - [ ] Plan file located and loaded
 - [ ] Session Goal understood
+- [ ] Working branch created or confirmed
 - [ ] Context files read
 - [ ] Tasks parsed with Do/Acceptance sections
 - [ ] Relevant skills pre-loaded based on task types


### PR DESCRIPTION
## Summary
- Add `SessionStart` hook that detects in-progress work (uncommitted files, unpushed feature branches, stashes) when opening a new Claude Code session
- Add auto-branching step to `/execute` workflow — derives a `feature/*` branch from the plan filename before starting work
- Update skill registry (README.md) with new hook entry

## Changes
- **New:** `.claude/hooks/session-start-check.sh` — startup awareness script
- **Edit:** `.claude/settings.json` — SessionStart hook config
- **Edit:** `.claude/skills/execute-plan.md` — Step 2: Create Working Branch
- **Edit:** `.claude/commands/execute.md` — mention branch creation in flow
- **Edit:** `.claude/README.md` — hook registry + file structure

## Test plan
- [ ] Open a new Claude Code session in the project — should see in-progress work summary if any exists
- [ ] Run `/execute` on a plan — should create a `feature/*` branch automatically
- [ ] Existing git safety hooks still work (push to main still blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)