### PR TITLE
Workout complete polish: fixed header, mood icons, card wrapping

### DIFF
--- a/.claude/plans/SESSION_PLAN_clear_logo.md
+++ b/.claude/plans/SESSION_PLAN_clear_logo.md
@@ -1,0 +1,117 @@
+# Session Plan: ClearLogo Component
+
+## Session Goal
+Create a reusable `<ClearLogo />` React component that renders the Clear wordmark with a glowing scan line and brightness differential treatment.
+
+## Context
+- Reference: `design-tokens.json`, `src/index.css` for token values
+- Visual spec: The HTML prototype at `.claude/inbox/clear-logo-exploration.html` (drop this file alongside this plan)
+- Current state: No logo component exists. "CLEAR" text is likely hardcoded wherever it appears.
+
+---
+
+## Design Spec
+
+The logo is the word **CLEAR** in **Oxanium Bold, uppercase, wide letter-spacing (0.18em)**, split by a horizontal scan line.
+
+### Core Treatment: Brightness Differential + Glow Scanline
+- The text is split into two halves by a horizontal line at ~57% from top
+- **Top half:** full brightness (`--color-text-primary` / near-white)
+- **Bottom half:** reduced brightness (~55% opacity of the same color)
+- **Scan line:** a 1-2px horizontal bar in theme orange, extending 12% beyond the wordmark on each side
+- **Scan line glow:** `box-shadow` using theme orange at multiple blur radii (8px/20px/40px, decreasing opacity)
+
+### Color Rules
+- Use CSS custom properties from the existing design system, NOT hardcoded hex values
+- The scan line color should use the theme's primary/accent orange token
+- Text color should use the existing text color token
+- This should respect theme switching if the app supports it
+
+### Sizes
+The component needs a `size` prop with these presets:
+
+| Size | Font Size | Scan Line Height | Context |
+|------|-----------|------------------|---------|
+| `sm` | 14px | 1px | Nav bar |
+| `md` | 24px | 1px | Header |
+| `lg` | 48px | 2px | Feature |
+| `xl` | 72px | 2px | Hero / Splash |
+
+### Boot Animation (optional prop)
+When `boot={true}` is passed:
+1. The wordmark starts hidden (masked)
+2. The scan line starts at the top
+3. On mount, the scan line sweeps down to its resting position (57%) over ~800ms with `cubic-bezier(0.16, 0.6, 0.4, 1)` easing
+4. As the scan line passes, it reveals the text behind it (the mask recedes)
+5. The scan line then stays at its resting position — this is the static logo
+
+The animation plays once on mount. Without the `boot` prop, the logo renders in its final static state immediately.
+
+### Icon Variant
+When `variant="icon"` is passed:
+- Renders only the letter **C** (same font treatment)
+- Inside a container with `border-radius: 16px` and a subtle orange border at ~15% opacity
+- The scan line cuts through the C at the same 54% position
+- Background is the app's dark background color
+- Use this for favicon or small icon contexts
+
+---
+
+## Tasks
+
+### 1. Create the ClearLogo component
+
+**Do:**
+- Create `src/components/ClearLogo.tsx` (or `.jsx`, match the project's convention)
+- Implement the brightness differential using CSS `clip-path: inset(...)` to split the text into top/bottom halves
+- Implement the scan line as a positioned pseudo-element or a styled div
+- Add the glow via box-shadow on the scan line
+- Props: `size` (sm/md/lg/xl, default md), `boot` (boolean, default false), `variant` ("wordmark" | "icon", default "wordmark")
+- Use Tailwind classes where they exist for the values you need; use inline styles or a small CSS module only for things Tailwind can't express (clip-path, specific box-shadow with theme colors, animation keyframes)
+
+**Acceptance:**
+- `<ClearLogo />` renders the brightness differential wordmark with glowing scan line at `md` size
+- `<ClearLogo size="xl" boot />` plays the scan-down reveal animation once on mount
+- `<ClearLogo variant="icon" size="lg" />` renders the C-in-container icon
+- No hardcoded color hex values — all colors reference design tokens / CSS custom properties
+- Component works on dark backgrounds (the only background it'll ever be on)
+
+---
+
+### 2. Replace existing CLEAR text with the component
+
+**Do:**
+- Search the codebase for any hardcoded "CLEAR" text used as branding/logo (headers, splash screens, etc.)
+- Replace with `<ClearLogo />` using the appropriate size prop for context
+- If there's a splash/loading screen, use `<ClearLogo size="xl" boot />` there
+
+**Acceptance:**
+- All branding instances of "CLEAR" now use the component
+- Sizes are appropriate to context (small in nav, large in splash)
+- Boot animation only plays on splash/loading — not in the persistent header
+
+---
+
+### 3. Add Oxanium font if not already loaded
+
+**Do:**
+- Check if Oxanium is already imported in the project (it should be — it's in the design system)
+- If not, add it via Google Fonts import or local font file, matching how other project fonts are loaded
+- The logo component should reference `font-family: 'Oxanium'` (or the Tailwind class if one is configured)
+
+**Acceptance:**
+- Oxanium Bold renders correctly in the logo
+- No FOUT (flash of unstyled text) — font loading matches existing pattern
+
+---
+
+## Design System Compliance
+- All colors via CSS custom properties / design tokens — zero hardcoded hex
+- Font: Oxanium Bold, uppercase, letter-spacing 0.18em
+- Follow existing component file patterns (check how other shared components are structured)
+- The HTML prototype is a visual reference, not code to copy — translate the intent into idiomatic React using the project's patterns
+
+## After Session
+- [ ] Update SESSION_LOG.md with: Date, Tasks Completed, Files Touched
+- [ ] Update PROJECT_MAP.md if a new shared components directory was created
+- [ ] Confirm: "Session complete. ClearLogo component created and integrated. Log updated."

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-03-04 (5th session)
+**Last Session:** 2026-03-04 (6th session)
 
 ---
 
@@ -13,14 +13,59 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** UI Refinement — design token compliance, exercise card rework
-**Current Task:** Complete — full UI sweep across 31 files on `feature/clear-logo`
-**Last Completed:** Exercise card accordion rewrite, CTA token compliance, sticky/blur fixes
+**Current Phase:** UI Polish — workout complete screen, fixed header, mood icons
+**Current Task:** Complete — workout complete polish on `feature/workout-complete-polish`
+**Last Completed:** Fixed header positioning, custom MoodIcon SVGs, Card wrapping, streak token alignment
 **Blocking Issues:** None — build passes, ready for PR
 
 ---
 
 ## Session Entries
+
+### Session: 2026-03-04 - Workout Complete Polish: Fixed Header, Mood Icons, Card Wrapping
+
+**Duration:** ~1.5 hours
+**Mode:** Claude Code
+**Branch:** `feature/workout-complete-polish`
+
+#### What Got Done
+- **Fixed PageHeader positioning**: Changed from `sticky top-0` to `fixed top-0 left-0 right-0` so header stays locked to viewport on long-scrolling pages. Updated all 4 layouts (AppLayout, WorkoutLayout, OnboardingLayout, AuthLayout) with `pt-12` clearance for the fixed header height
+- **Custom MoodIcon component**: Created 5 angular/geometric SVG mood faces (Exhausted: X eyes + zigzag frown, Tough: dash eyes + angled frown, Okay: square dot eyes + flat mouth, Good: square dot eyes + V smile, Great: ^ happy eyes + wide V smile). All share a chamfered square frame matching the design system's low-tech sci-fi style. Uses `currentColor` for parent-controlled coloring
+- **Card wrapping**: Wrapped mood selector and session notes textarea in `<Card padding="md">` with section labels inside, matching the visual rhythm of summary and streak cards
+- **Glow treatment**: Added `.glow-emissive` to "Nice Work!" heading and new streak number for celebration emphasis
+- **Streak token alignment**: Replaced hardcoded color primitives in streak day cells with radio button tokens (`--surface-radio-selected`, `--border-radio-select`, etc.) matching HomeScreen. Changed from flex to grid layout for consistent cell sizing
+- **Cleanup**: Removed unused `cn` import, removed lucide mood icon dependency from SummaryScreen
+
+#### What Came Up (Unexpected)
+- `sticky` positioning was failing on long pages because of CSS stacking context issues — `fixed` was the proper solution but required coordinated padding changes across all layout components
+- Anthropic API billing issue caused ~30 min of debugging — Edge Function returned 500, turned out to be "credit balance too low" on Anthropic's side despite credits showing in dashboard. Resolved itself after propagation delay
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| `position: fixed` not `sticky` for PageHeader | Sticky can break in certain scroll/transform contexts; fixed locks to viewport reliably |
+| `pt-12` clearance on all layouts | Header is h-12 (48px). Top padding compensates so content doesn't render behind fixed header |
+| Angular/geometric mood faces (not rounded emoji) | Matches design philosophy: "low-tech sci-fi", shapes should be angular with chamfered frames |
+| MoodIcon uses `currentColor` inheritance | Parent controls color via style props, matching existing radio button selection pattern |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `src/components/MoodIcon.tsx` | Created — 5 geometric SVG mood faces with shared chamfered frame |
+| `src/components/PageHeader.tsx` | Modified — sticky → fixed positioning |
+| `src/layouts/AppLayout.tsx` | Modified — header outside max-w-md, pt-12 clearance |
+| `src/layouts/WorkoutLayout.tsx` | Modified — pt-14 clearance for fixed header |
+| `src/layouts/OnboardingLayout.tsx` | Modified — header outside max-w-md, pt-12 clearance |
+| `src/layouts/AuthLayout.tsx` | Modified — pt-12 clearance |
+| `src/pages/SummaryScreen.tsx` | Modified — Card wrapping, MoodIcon integration, glow, streak tokens |
+| `.claude/plans/SESSION_PLAN_clear_logo.md` | Added — archived plan from previous session |
+
+#### Status
+- Build passes, TypeScript compiles cleanly
+- 1 commit on `feature/workout-complete-polish` ahead of main
+- Ready for PR
+
+---
 
 ### Session: 2026-03-04 - UI Refinement: Design Token Compliance & Exercise Card Rework
 

--- a/src/components/MoodIcon.tsx
+++ b/src/components/MoodIcon.tsx
@@ -1,0 +1,157 @@
+export type MoodValue = 1 | 2 | 3 | 4 | 5;
+
+interface MoodIconProps {
+  mood: MoodValue;
+  size?: number;
+}
+
+/**
+ * Geometric mood face SVGs for the workout complete screen.
+ * Angular/square frames with minimal line features — cutesy but mechanical.
+ * Color is inherited from the parent via currentColor.
+ */
+export function MoodIcon({ mood, size = 32 }: MoodIconProps) {
+  const s = size;
+  const strokeWidth = 2;
+
+  // All icons share a square frame with chamfered top-right corner
+  const frameInset = 2; // inset from edge so strokes aren't clipped
+  const fi = frameInset;
+  const fs = s - frameInset; // frame size end
+  const chamfer = 6; // top-right chamfer size
+
+  const frame = `M ${fi} ${fi} L ${fs - chamfer} ${fi} L ${fs} ${fi + chamfer} L ${fs} ${fs} L ${fi} ${fs} Z`;
+
+  return (
+    <svg
+      width={s}
+      height={s}
+      viewBox={`0 0 ${s} ${s}`}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="square"
+      strokeLinejoin="miter"
+    >
+      {/* Shared frame */}
+      <path d={frame} />
+
+      {/* Face features per mood */}
+      {mood === 1 && <ExhaustedFace s={s} />}
+      {mood === 2 && <ToughFace s={s} />}
+      {mood === 3 && <OkayFace s={s} />}
+      {mood === 4 && <GoodFace s={s} />}
+      {mood === 5 && <GreatFace s={s} />}
+    </svg>
+  );
+}
+
+// --- Individual face features ---
+
+/** Exhausted: X eyes, wavy/zigzag frown */
+function ExhaustedFace({ s }: { s: number }) {
+  const cx = s / 2;
+  const eyeY = s * 0.38;
+  const eyeL = cx - s * 0.17;
+  const eyeR = cx + s * 0.17;
+  const e = s * 0.06; // eye cross half-size
+
+  return (
+    <>
+      {/* X left eye */}
+      <line x1={eyeL - e} y1={eyeY - e} x2={eyeL + e} y2={eyeY + e} />
+      <line x1={eyeL + e} y1={eyeY - e} x2={eyeL - e} y2={eyeY + e} />
+      {/* X right eye */}
+      <line x1={eyeR - e} y1={eyeY - e} x2={eyeR + e} y2={eyeY + e} />
+      <line x1={eyeR + e} y1={eyeY - e} x2={eyeR - e} y2={eyeY + e} />
+      {/* Zigzag frown */}
+      <polyline
+        points={`${cx - s * 0.22},${s * 0.68} ${cx - s * 0.11},${s * 0.62} ${cx},${s * 0.68} ${cx + s * 0.11},${s * 0.62} ${cx + s * 0.22},${s * 0.68}`}
+        fill="none"
+      />
+    </>
+  );
+}
+
+/** Tough: dash eyes, angled frown */
+function ToughFace({ s }: { s: number }) {
+  const cx = s / 2;
+  const eyeY = s * 0.38;
+  const eyeL = cx - s * 0.17;
+  const eyeR = cx + s * 0.17;
+  const ew = s * 0.07; // eye dash half-width
+
+  return (
+    <>
+      {/* Dash eyes */}
+      <line x1={eyeL - ew} y1={eyeY} x2={eyeL + ew} y2={eyeY} />
+      <line x1={eyeR - ew} y1={eyeY} x2={eyeR + ew} y2={eyeY} />
+      {/* Angled frown — left corner lower */}
+      <polyline
+        points={`${cx - s * 0.2},${s * 0.68} ${cx + s * 0.2},${s * 0.62}`}
+        fill="none"
+      />
+    </>
+  );
+}
+
+/** Okay: dot eyes, flat line mouth */
+function OkayFace({ s }: { s: number }) {
+  const cx = s / 2;
+  const eyeY = s * 0.38;
+  const eyeL = cx - s * 0.17;
+  const eyeR = cx + s * 0.17;
+
+  return (
+    <>
+      {/* Square dot eyes */}
+      <rect x={eyeL - 1.5} y={eyeY - 1.5} width={3} height={3} fill="currentColor" stroke="none" />
+      <rect x={eyeR - 1.5} y={eyeY - 1.5} width={3} height={3} fill="currentColor" stroke="none" />
+      {/* Flat mouth */}
+      <line x1={cx - s * 0.15} y1={s * 0.65} x2={cx + s * 0.15} y2={s * 0.65} />
+    </>
+  );
+}
+
+/** Good: dot eyes, angled smile */
+function GoodFace({ s }: { s: number }) {
+  const cx = s / 2;
+  const eyeY = s * 0.38;
+  const eyeL = cx - s * 0.17;
+  const eyeR = cx + s * 0.17;
+
+  return (
+    <>
+      {/* Square dot eyes */}
+      <rect x={eyeL - 1.5} y={eyeY - 1.5} width={3} height={3} fill="currentColor" stroke="none" />
+      <rect x={eyeR - 1.5} y={eyeY - 1.5} width={3} height={3} fill="currentColor" stroke="none" />
+      {/* V smile */}
+      <polyline
+        points={`${cx - s * 0.18},${s * 0.62} ${cx},${s * 0.7} ${cx + s * 0.18},${s * 0.62}`}
+        fill="none"
+      />
+    </>
+  );
+}
+
+/** Great: ^ happy eyes, wide V smile */
+function GreatFace({ s }: { s: number }) {
+  const cx = s / 2;
+  const eyeY = s * 0.38;
+  const eyeL = cx - s * 0.17;
+  const eyeR = cx + s * 0.17;
+  const ew = s * 0.06;
+
+  return (
+    <>
+      {/* ^ happy eyes (inverted V) */}
+      <polyline points={`${eyeL - ew},${eyeY + ew * 0.5} ${eyeL},${eyeY - ew * 0.5} ${eyeL + ew},${eyeY + ew * 0.5}`} fill="none" />
+      <polyline points={`${eyeR - ew},${eyeY + ew * 0.5} ${eyeR},${eyeY - ew * 0.5} ${eyeR + ew},${eyeY + ew * 0.5}`} fill="none" />
+      {/* Wide V smile */}
+      <polyline
+        points={`${cx - s * 0.22},${s * 0.6} ${cx},${s * 0.72} ${cx + s * 0.22},${s * 0.6}`}
+        fill="none"
+      />
+    </>
+  );
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -99,7 +99,7 @@ export const PageHeader = ({
   };
 
   return (
-    <header className="sticky top-0 z-40 flex items-stretch h-12 backdrop-blur-xl">
+    <header className="fixed top-0 left-0 right-0 z-40 flex items-stretch h-12 backdrop-blur-xl">
       {/* Main body — chamfered frame, bottom border only, no accent bar */}
       <ChamferedFrame
         cornerSize="md"

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -9,8 +9,8 @@ interface AppLayoutProps {
 export const AppLayout = ({ header, footer, children }: AppLayoutProps) => {
   return (
     <div className="min-h-screen grain-overlay">
-      <div className={`max-w-md mx-auto ${footer ? 'pb-32' : 'pb-8'}`}>
-        {header}
+      {header}
+      <div className={`max-w-md mx-auto pt-12 ${footer ? 'pb-32' : 'pb-8'}`}>
         <div className="px-4">
           {children}
         </div>

--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -9,7 +9,7 @@ export const AuthLayout = ({ header, children }: AuthLayoutProps) => {
   return (
     <div className="min-h-screen grain-overlay flex flex-col">
       {header}
-      <div className="flex-1 flex flex-col px-6">
+      <div className="flex-1 flex flex-col px-6 pt-12">
         {children}
       </div>
     </div>

--- a/src/layouts/OnboardingLayout.tsx
+++ b/src/layouts/OnboardingLayout.tsx
@@ -9,8 +9,8 @@ interface OnboardingLayoutProps {
 export const OnboardingLayout = ({ header, footer, children }: OnboardingLayoutProps) => {
   return (
     <div className="min-h-screen grain-overlay">
-      <div className="max-w-md mx-auto pb-32">
-        {header}
+      {header}
+      <div className="max-w-md mx-auto pt-12 pb-32">
         <div className="px-4">
           {children}
         </div>

--- a/src/layouts/WorkoutLayout.tsx
+++ b/src/layouts/WorkoutLayout.tsx
@@ -16,7 +16,7 @@ export const WorkoutLayout = ({ header, footer, children, onTouchStart, onTouchE
       onTouchEnd={onTouchEnd}
     >
       {header}
-      <div className="max-w-md mx-auto w-full px-4 pt-2">
+      <div className="max-w-md mx-auto w-full px-4 pt-14">
         {children}
       </div>
       {footer}

--- a/src/pages/SummaryScreen.tsx
+++ b/src/pages/SummaryScreen.tsx
@@ -1,21 +1,21 @@
 import { useState } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
-import { Flame, Frown, Meh, Smile, SmilePlus, ThumbsDown } from "lucide-react";
+import { Flame } from "lucide-react";
+import { MoodIcon, MoodValue } from "@/components/MoodIcon";
 import { PageHeader } from "@/components/PageHeader";
 import { AppLayout } from "@/layouts";
-import { cn } from "@/lib/utils";
 import { CTAButton } from "@/components/CTAButton";
 import { Card } from "@/components/Card";
 import { Textarea } from "@/components/ui/textarea";
 import { useWorkoutFlowContext } from "@/contexts/WorkoutFlowContext";
 import { useHomeDataContext } from "@/contexts/HomeDataContext";
 
-const MOOD_OPTIONS = [
-  { value: 1, icon: ThumbsDown, label: "Exhausted" },
-  { value: 2, icon: Frown, label: "Tough" },
-  { value: 3, icon: Meh, label: "Okay" },
-  { value: 4, icon: Smile, label: "Good" },
-  { value: 5, icon: SmilePlus, label: "Great" },
+const MOOD_OPTIONS: { value: MoodValue; label: string }[] = [
+  { value: 1, label: "Exhausted" },
+  { value: 2, label: "Tough" },
+  { value: 3, label: "Okay" },
+  { value: 4, label: "Good" },
+  { value: 5, label: "Great" },
 ];
 
 const formatDuration = (seconds: number): string => {
@@ -92,7 +92,7 @@ export const SummaryScreen = () => {
 
         <div className="text-center mb-6">
           <h2
-            className="text-heading-h2 font-bold uppercase tracking-wide"
+            className="text-heading-h2 font-bold uppercase tracking-wide glow-emissive"
             style={{ color: 'var(--text-header)' }}
           >
             Nice Work!
@@ -111,38 +111,36 @@ export const SummaryScreen = () => {
           </p>
         </Card>
 
-        <div className="mb-6">
+        <Card padding="md" className="mb-6">
           <h3
-            className="text-label-xs uppercase tracking-widest mb-3"
+            className="text-label-xs uppercase tracking-widest mb-4"
             style={{ color: 'var(--text-card-label)' }}
           >
             How Do You Feel?
           </h3>
           <div className="flex justify-between gap-2">
-            {MOOD_OPTIONS.map((mood) => {
-              const Icon = mood.icon;
-              return (
-                <button
-                  key={mood.value}
-                  onClick={() => setSelectedMood(mood.value)}
-                  className={cn("flex-1 py-3 flex items-center justify-center transition-all border")}
-                  style={
-                    selectedMood === mood.value
-                      ? { backgroundColor: 'var(--surface-radio-selected)', borderColor: 'var(--border-radio-select)', color: 'var(--text-label-selected)' }
-                      : { backgroundColor: 'transparent', borderColor: 'transparent', color: 'var(--text-paragraph)' }
-                  }
-                  aria-label={mood.label}
-                >
-                  <Icon size={24} />
-                </button>
-              );
-            })}
+            {MOOD_OPTIONS.map((mood) => (
+              <button
+                key={mood.value}
+                onClick={() => setSelectedMood(mood.value)}
+                className="flex-1 py-3 flex flex-col items-center justify-center gap-2 transition-all border"
+                style={
+                  selectedMood === mood.value
+                    ? { backgroundColor: 'var(--surface-radio-selected)', borderColor: 'var(--border-radio-select)', color: 'var(--text-label-selected)' }
+                    : { backgroundColor: 'transparent', borderColor: 'transparent', color: 'var(--text-paragraph)', opacity: 0.5 }
+                }
+                aria-label={mood.label}
+              >
+                <MoodIcon mood={mood.value} size={28} />
+                <span className="text-label-xs">{mood.label}</span>
+              </button>
+            ))}
           </div>
-        </div>
+        </Card>
 
-        <div className="mb-6">
+        <Card padding="md" className="mb-6">
           <h3
-            className="text-label-xs uppercase tracking-widest mb-3"
+            className="text-label-xs uppercase tracking-widest mb-4"
             style={{ color: 'var(--text-card-label)' }}
           >
             Session Notes (Optional)
@@ -153,7 +151,7 @@ export const SummaryScreen = () => {
             placeholder="Add any notes about this workout..."
             className="min-h-[96px]"
           />
-        </div>
+        </Card>
 
         <Card padding="md">
           <h3
@@ -170,7 +168,7 @@ export const SummaryScreen = () => {
             <span className="text-heading-h2 font-bold mx-2" style={{ color: 'var(--icon-badge)' }}>
               &rarr;
             </span>
-            <span className="text-heading-h1 font-bold" style={{ color: 'var(--text-header)' }}>
+            <span className="text-heading-h1 font-bold glow-emissive" style={{ color: 'var(--text-header)' }}>
               {newStreak}
             </span>
             <span className="ml-2">
@@ -179,22 +177,18 @@ export const SummaryScreen = () => {
             <p className="text-label-sm mt-1" style={{ color: 'var(--text-paragraph)' }}>days</p>
           </div>
 
-          <div className="flex justify-between gap-1">
+          <div className="grid grid-cols-7 gap-2">
             {weekDays.map((day, index) => (
               <div key={index} className="flex flex-col items-center gap-1">
                 <div
-                  className={cn(
-                    "w-8 h-8 flex items-center justify-center border transition-all",
-                    day.isToday && "ring-2 ring-offset-1"
-                  )}
-                  style={{
-                    ...(day.status === "workout"
-                      ? { backgroundColor: 'var(--color-green-alpha-200)', borderColor: 'var(--border-success)', color: 'var(--text-label-selected)' }
+                  className="aspect-square w-full max-w-10 flex items-center justify-center border transition-all"
+                  style={
+                    day.status === "workout"
+                      ? { backgroundColor: 'var(--surface-radio-selected)', borderColor: 'var(--border-radio-select)', color: 'var(--text-label-selected)' }
                       : day.status === "rest"
-                      ? { backgroundColor: 'var(--color-blue-alpha-200)', borderColor: 'var(--border-info)', color: 'var(--icon-cta)' }
-                      : { backgroundColor: 'transparent', borderColor: 'var(--color-neutral-alpha-300)', color: 'var(--text-disabled)' }),
-                    ...(day.isToday ? { '--tw-ring-color': 'var(--border-card)', '--tw-ring-offset-color': 'var(--color-neutral-900)' } as React.CSSProperties : {}),
-                  }}
+                      ? { backgroundColor: 'var(--surface-radio-unselect)', borderColor: 'var(--border-radio-unselected)', color: 'var(--icon-cta)' }
+                      : { backgroundColor: 'transparent', borderColor: 'transparent', color: 'var(--text-disabled)' }
+                  }
                 >
                   {day.status === "workout" ? "\u25CF" : day.status === "rest" ? "\u25D0" : "\u25CB"}
                 </div>


### PR DESCRIPTION
## Summary
- Fix PageHeader from `sticky` to `fixed` positioning so it stays locked on long-scrolling pages (all 4 layouts updated with clearance padding)
- Create custom `MoodIcon` component with 5 angular/geometric SVG mood faces matching the low-tech sci-fi design language
- Wrap mood selector and session notes in `<Card>` for consistent visual rhythm across the workout complete screen
- Add `.glow-emissive` treatment to celebration elements ("Nice Work!" heading, new streak number)
- Align streak day cell tokens with HomeScreen (radio button pattern instead of hardcoded primitives)

## Test plan
- [ ] Scroll down on long pages (Review, Workout) — header should stay fixed at top
- [ ] Complete a workout and verify mood icons render with angular/geometric faces
- [ ] Select a mood — should highlight green with selected tokens
- [ ] Verify streak day cells match HomeScreen styling
- [ ] Toggle between orange and blue themes — all tokens should adapt
- [ ] Check on 375px viewport — all elements should fit without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)