### PR TITLE
Workout complete polish round 2: mood fill, streak frames, finish fix

### DIFF
--- a/src/components/MoodIcon.tsx
+++ b/src/components/MoodIcon.tsx
@@ -3,14 +3,17 @@ export type MoodValue = 1 | 2 | 3 | 4 | 5;
 interface MoodIconProps {
   mood: MoodValue;
   size?: number;
+  /** When true, frame fills with green and features use on-fill color */
+  selected?: boolean;
 }
 
 /**
  * Geometric mood face SVGs for the workout complete screen.
  * Angular/square frames with minimal line features — cutesy but mechanical.
  * Color is inherited from the parent via currentColor.
+ * When selected, the frame fills with green and features render in a contrasting color.
  */
-export function MoodIcon({ mood, size = 32 }: MoodIconProps) {
+export function MoodIcon({ mood, size = 32, selected = false }: MoodIconProps) {
   const s = size;
   const strokeWidth = 2;
 
@@ -33,8 +36,12 @@ export function MoodIcon({ mood, size = 32 }: MoodIconProps) {
       strokeLinecap="square"
       strokeLinejoin="miter"
     >
-      {/* Shared frame */}
-      <path d={frame} />
+      {/* Shared frame — filled when selected */}
+      <path
+        d={frame}
+        fill={selected ? 'var(--surface-radio-selected)' : 'none'}
+        stroke={selected ? 'var(--border-radio-select)' : 'currentColor'}
+      />
 
       {/* Face features per mood */}
       {mood === 1 && <ExhaustedFace s={s} />}

--- a/src/hooks/useWorkoutSession.ts
+++ b/src/hooks/useWorkoutSession.ts
@@ -45,30 +45,36 @@ export const useWorkoutSession = ({
         logger.workout.debug('handleFinishSession called', { currentSessionId, totalTime: String(totalTime), durationMins: String(durationMins) });
 
         // Save completion data to database if we have a session
-        if (currentSessionId) {
-            const result = await completeWorkoutSession(currentSessionId, {
-                durationMins,
-                mood,
-                sessionNotes,
-            });
-
-            if (result.error) {
-                toast.error("Failed to save workout", {
-                    description: "Your progress may not have been recorded.",
+        try {
+            if (currentSessionId) {
+                const result = await completeWorkoutSession(currentSessionId, {
+                    durationMins,
+                    mood,
+                    sessionNotes,
                 });
+
+                if (result.error) {
+                    toast.error("Failed to save workout", {
+                        description: "Your progress may not have been recorded.",
+                    });
+                } else {
+                    toast.success("Session saved!", {
+                        description: "Your workout has been recorded.",
+                    });
+                }
             } else {
-                toast.success("Session saved!", {
-                    description: "Your workout has been recorded.",
+                toast.success("Session complete!", {
+                    description: "Demo workout - not saved to history.",
                 });
             }
-        } else {
-            // Mock workout, just show success
-            toast.success("Session complete!", {
-                description: "Demo workout - not saved to history.",
+        } catch (err) {
+            logger.workout.error('handleFinishSession error', { error: err instanceof Error ? err.message : String(err) });
+            toast.error("Something went wrong", {
+                description: "Your workout may not have been saved.",
             });
         }
 
-        // Navigate first, then reset state and reload data
+        // Always navigate and reset — even if save failed
         if (onSuccess) onSuccess();
         setGeneratedWorkout(null);
         setWorkoutNotes(null);

--- a/src/pages/CreateAccountScreen.tsx
+++ b/src/pages/CreateAccountScreen.tsx
@@ -74,7 +74,7 @@ export const CreateAccountScreen = () => {
 
   return (
     <AuthLayout header={<PageHeader left="back" onBack={() => navigate("/welcome")} />}>
-      <div className="flex-1 flex flex-col justify-center max-w-sm mx-auto w-full">
+      <div className="flex-1 flex flex-col justify-center max-w-sm mx-auto w-full stagger-reveal">
         {/* Title */}
         <h1
           className="text-heading-h1 font-bold tracking-wider mb-2"

--- a/src/pages/HomeScreen.tsx
+++ b/src/pages/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from "@/components/PageHeader";
 import { AppLayout } from "@/layouts";
 import { CTAButton } from "@/components/CTAButton";
 import { Card } from "@/components/Card";
+import { ChamferedFrame } from "@/components/ChamferedFrame";
 import { Zap, Clock, Flame, Dumbbell } from "lucide-react";
 import { LoadingSkeleton } from "@/components/LoadingSkeleton";
 import { ErrorState } from "@/components/ErrorState";
@@ -190,28 +191,34 @@ export const HomeScreen = () => {
           </div>
 
           <div className="grid grid-cols-7 gap-2 mb-4">
-            {weekDays.map((day, index) => (
-              <div key={index} className="flex flex-col items-center gap-1">
-                <div
-                  className="aspect-square w-full max-w-10 flex items-center justify-center border transition-all"
-                  style={
-                    day.status === "workout"
-                      ? { backgroundColor: 'var(--surface-radio-selected)', borderColor: 'var(--border-radio-select)', color: 'var(--text-label-selected)' }
-                      : day.status === "rest"
-                      ? { backgroundColor: 'var(--surface-radio-unselect)', borderColor: 'var(--border-radio-unselected)', color: 'var(--icon-cta)' }
-                      : { backgroundColor: 'transparent', borderColor: 'transparent', color: 'var(--text-disabled)' }
-                  }
-                >
-                  {day.status === "workout" ? "\u25CF" : day.status === "rest" ? "\u25D0" : "\u25CB"}
+            {weekDays.map((day, index) => {
+              const isWorkout = day.status === "workout";
+              const isRest = day.status === "rest";
+              return (
+                <div key={index} className="flex flex-col items-center gap-1">
+                  <ChamferedFrame
+                    cornerSize="sm"
+                    surfaceColor={isWorkout ? 'var(--surface-radio-selected)' : isRest ? 'var(--surface-info)' : 'transparent'}
+                    borderColor={isWorkout ? 'var(--border-radio-select)' : isRest ? 'var(--border-info)' : 'var(--border-radio-unselected)'}
+                    hasLeftBorder={true}
+                    className="aspect-square w-full max-w-10"
+                  >
+                    <div
+                      className="w-full h-full flex items-center justify-center text-label-sm"
+                      style={{ color: isWorkout ? 'var(--text-label-selected)' : isRest ? 'var(--color-purple-500)' : 'var(--text-disabled)' }}
+                    >
+                      {isWorkout ? "\u25CF" : isRest ? "\u25D0" : "\u25CB"}
+                    </div>
+                  </ChamferedFrame>
+                  <span className="text-label-xs" style={{ color: 'var(--text-disabled)' }}>{day.label}</span>
                 </div>
-                <span className="text-label-xs" style={{ color: 'var(--text-disabled)' }}>{day.label}</span>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
-          <CTAButton onClick={handleMarkRestDay} variant="secondary" size="sm" fullWidth>
+          {streakData.weekView[new Date().toISOString().split('T')[0]] !== 'workout' && <CTAButton onClick={handleMarkRestDay} variant="secondary" size="sm" fullWidth>
             Mark Rest Day
-          </CTAButton>
+          </CTAButton>}
         </Card>
 
         {isLoading ? (

--- a/src/pages/OnboardingScreen.tsx
+++ b/src/pages/OnboardingScreen.tsx
@@ -180,7 +180,7 @@ export const OnboardingScreen = () => {
       header={<PageHeader left={step > 1 ? 'back' : undefined} onBack={handleBack} />}
       footer={onboardingFooter}
     >
-      <div className="pt-6">
+      <div className="pt-6 stagger-reveal">
           {/* Step 1: Equipment/Location */}
           {step === 1 && (
             <div className="space-y-6">

--- a/src/pages/ReviewScreen.tsx
+++ b/src/pages/ReviewScreen.tsx
@@ -26,7 +26,7 @@ export const ReviewScreen = () => {
       header={<PageHeader left="back" onBack={() => navigate("/generate")} right="menu" onMenu={() => navigate("/settings")} />}
       footer={<StartWorkoutButton onClick={() => handleStartWorkout(() => navigate("/workout"))} />}
     >
-      <div className="pt-6 space-y-6">
+      <div className="pt-6 space-y-6 stagger-reveal">
         <WorkoutOverview workout={generatedWorkout} />
 
         <div className="space-y-4">

--- a/src/pages/SessionDetailScreen.tsx
+++ b/src/pages/SessionDetailScreen.tsx
@@ -51,7 +51,7 @@ export const SessionDetailScreen = () => {
 
   return (
     <AppLayout header={<PageHeader left="back" onBack={() => navigate("/history")} center="Session" right="menu" onMenu={() => navigate("/settings")} />}>
-      <div className="pt-6">
+      <div className="pt-6 stagger-reveal">
         {isLoading || !workout ? (
           <LoadingSkeleton count={4} />
         ) : (

--- a/src/pages/SettingsScreen.tsx
+++ b/src/pages/SettingsScreen.tsx
@@ -304,7 +304,7 @@ export const SettingsScreen = () => {
       header={<PageHeader left="back" onBack={handleBack} center={getTitle()} />}
       footer={saveFooter}
     >
-      <div className="pt-6">
+      <div className="pt-6 stagger-reveal">
       {currentView === "hub" && (
         <SettingsHub
           preferences={preferences}

--- a/src/pages/SignInScreen.tsx
+++ b/src/pages/SignInScreen.tsx
@@ -64,7 +64,7 @@ export const SignInScreen = () => {
 
   return (
     <AuthLayout header={<PageHeader left="back" onBack={() => navigate("/welcome")} />}>
-      <div className="flex-1 flex flex-col justify-center max-w-sm mx-auto w-full">
+      <div className="flex-1 flex flex-col justify-center max-w-sm mx-auto w-full stagger-reveal">
         {/* Title */}
         <h1
           className="text-heading-h1 font-bold tracking-wider mb-2"

--- a/src/pages/SummaryScreen.tsx
+++ b/src/pages/SummaryScreen.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from "@/components/PageHeader";
 import { AppLayout } from "@/layouts";
 import { CTAButton } from "@/components/CTAButton";
 import { Card } from "@/components/Card";
+import { ChamferedFrame } from "@/components/ChamferedFrame";
 import { Textarea } from "@/components/ui/textarea";
 import { useWorkoutFlowContext } from "@/contexts/WorkoutFlowContext";
 import { useHomeDataContext } from "@/contexts/HomeDataContext";
@@ -63,8 +64,8 @@ export const SummaryScreen = () => {
 
   const weekDays = getWeekDays();
 
-  const handleFinish = () => {
-    handleFinishSession(selectedMood, sessionNotes, () => navigate("/"));
+  const handleFinish = async () => {
+    await handleFinishSession(selectedMood, sessionNotes, () => navigate("/"));
   };
 
   const finishFooter = (
@@ -81,15 +82,8 @@ export const SummaryScreen = () => {
   );
 
   return (
-    <AppLayout header={<PageHeader />} footer={finishFooter}>
-      <div className="pt-6 pb-24">
-        <h1
-          className="text-heading-h4 font-bold uppercase tracking-wider mb-6"
-          style={{ color: 'var(--text-header)' }}
-        >
-          Workout Complete
-        </h1>
-
+    <AppLayout header={<PageHeader center="Workout Complete" />} footer={finishFooter}>
+      <div className="pt-6 pb-24 stagger-reveal">
         <div className="text-center mb-6">
           <h2
             className="text-heading-h2 font-bold uppercase tracking-wide glow-emissive"
@@ -101,7 +95,7 @@ export const SummaryScreen = () => {
 
         <Card padding="md" className="mb-6 text-center">
           <p
-            className="text-heading-h5 font-medium uppercase tracking-wide"
+            className="text-heading-h5 font-semibold uppercase tracking-wide"
             style={{ color: 'var(--text-header)' }}
           >
             {generatedWorkout.goal ? `${generatedWorkout.goal.replace('_', ' ')} · ` : ''}{generatedWorkout.anchor} &bull; Intensity {generatedWorkout.intensity}
@@ -119,22 +113,21 @@ export const SummaryScreen = () => {
             How Do You Feel?
           </h3>
           <div className="flex justify-between gap-2">
-            {MOOD_OPTIONS.map((mood) => (
-              <button
-                key={mood.value}
-                onClick={() => setSelectedMood(mood.value)}
-                className="flex-1 py-3 flex flex-col items-center justify-center gap-2 transition-all border"
-                style={
-                  selectedMood === mood.value
-                    ? { backgroundColor: 'var(--surface-radio-selected)', borderColor: 'var(--border-radio-select)', color: 'var(--text-label-selected)' }
-                    : { backgroundColor: 'transparent', borderColor: 'transparent', color: 'var(--text-paragraph)', opacity: 0.5 }
-                }
-                aria-label={mood.label}
-              >
-                <MoodIcon mood={mood.value} size={28} />
-                <span className="text-label-xs">{mood.label}</span>
-              </button>
-            ))}
+            {MOOD_OPTIONS.map((mood) => {
+              const isSelected = selectedMood === mood.value;
+              return (
+                <button
+                  key={mood.value}
+                  onClick={() => setSelectedMood(mood.value)}
+                  className="flex-1 py-3 flex flex-col items-center justify-center gap-2 transition-all"
+                  style={{ color: isSelected ? 'var(--text-label-selected)' : 'var(--text-paragraph)', opacity: isSelected ? 1 : 0.5 }}
+                  aria-label={mood.label}
+                >
+                  <MoodIcon mood={mood.value} size={32} selected={isSelected} />
+                  <span className="text-label-xs">{mood.label}</span>
+                </button>
+              );
+            })}
           </div>
         </Card>
 
@@ -178,23 +171,29 @@ export const SummaryScreen = () => {
           </div>
 
           <div className="grid grid-cols-7 gap-2">
-            {weekDays.map((day, index) => (
-              <div key={index} className="flex flex-col items-center gap-1">
-                <div
-                  className="aspect-square w-full max-w-10 flex items-center justify-center border transition-all"
-                  style={
-                    day.status === "workout"
-                      ? { backgroundColor: 'var(--surface-radio-selected)', borderColor: 'var(--border-radio-select)', color: 'var(--text-label-selected)' }
-                      : day.status === "rest"
-                      ? { backgroundColor: 'var(--surface-radio-unselect)', borderColor: 'var(--border-radio-unselected)', color: 'var(--icon-cta)' }
-                      : { backgroundColor: 'transparent', borderColor: 'transparent', color: 'var(--text-disabled)' }
-                  }
-                >
-                  {day.status === "workout" ? "\u25CF" : day.status === "rest" ? "\u25D0" : "\u25CB"}
+            {weekDays.map((day, index) => {
+              const isWorkout = day.status === "workout";
+              const isRest = day.status === "rest";
+              return (
+                <div key={index} className="flex flex-col items-center gap-1">
+                  <ChamferedFrame
+                    cornerSize="sm"
+                    surfaceColor={isWorkout ? 'var(--surface-radio-selected)' : isRest ? 'var(--surface-info)' : 'transparent'}
+                    borderColor={isWorkout ? 'var(--border-radio-select)' : isRest ? 'var(--border-info)' : 'var(--border-radio-unselected)'}
+                    hasLeftBorder={true}
+                    className="aspect-square w-full max-w-10"
+                  >
+                    <div
+                      className="w-full h-full flex items-center justify-center text-label-sm"
+                      style={{ color: isWorkout ? 'var(--text-label-selected)' : isRest ? 'var(--color-purple-500)' : 'var(--text-disabled)' }}
+                    >
+                      {isWorkout ? "\u25CF" : isRest ? "\u25D0" : "\u25CB"}
+                    </div>
+                  </ChamferedFrame>
+                  <span className="text-label-xs" style={{ color: 'var(--text-disabled)' }}>{day.label}</span>
                 </div>
-                <span className="text-label-xs" style={{ color: 'var(--text-disabled)' }}>{day.label}</span>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- Move "Workout Complete" title into PageHeader (replaces logo on summary screen)
- Mood selection: selected state fills the MoodIcon SVG with green instead of wrapping a box around the whole button
- Streak day cells use ChamferedFrame with corner cuts on both Home and Summary screens
- Rest day cells use purple/info color scheme to visually distinguish from workout days
- Fix finish button silently failing: try/catch + await ensures navigation always happens
- Hide "Mark Rest Day" when today already has a workout logged
- Add stagger-reveal load-in animation to 7 additional screens

## Test plan
- [ ] Complete a workout — finish button should navigate home and show toast
- [ ] Select a mood on summary — icon fills green, no box around button
- [ ] Streak cells have chamfered corner cuts on both Home and Summary
- [ ] Rest days show in purple, workout days in green, empty days neutral
- [ ] "Mark Rest Day" hidden after completing a workout today
- [ ] Navigate between screens — all should have stagger-reveal animation
- [ ] Both orange and blue themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)