### PR TITLE
Exercise swap, scan loader system, and UI polish

### DIFF
--- a/.claude/plans/SESSION_PLAN_exercise_swap.md
+++ b/.claude/plans/SESSION_PLAN_exercise_swap.md
@@ -1,0 +1,219 @@
+# SESSION PLAN: Exercise Swap (Phase A)
+
+## Session Goal
+Implement context-aware exercise swapping on the Review screen (Screen 2) — single exercise swap, unit swap for grouped structures, swap history with 3-swap limit.
+
+## Context
+- **Spec:** `Clear_-_Exercise_Swap_Spec.md` — READ THIS FULLY BEFORE STARTING
+- **Review screen wireframe:** `Clear_-_Screen_2__Review___Edit__Wireframe_.md`
+- **Data model / API shape:** `Clear_-_Data_Model_UPDATED.md` (see `POST /generate/section`)
+- **Prompt reference:** `Clear_-_Workout_Generation_Prompt_v3.md`
+- **Structure types:** `Clear_-_Structure_Types_Spec.md`
+- **Design tokens:** `design-tokens.json`, `design-tokens-colors.js`
+- **Existing types:** `src/types/generation.ts` — `ExerciseStructure` union type
+- **Existing section card:** `WorkoutSectionCard.tsx` — has `onRandomize` prop and `RefreshCw` icon
+- **Existing edge function:** `supabase/functions/generate-workout/index.ts` — DO NOT modify this, we're creating a new one
+- **Current state:** Review screen exists with "Randomize Section" button (not wired up). Exercise cards expand/collapse. No swap functionality exists yet.
+
+## Important: Read the Spec First
+The spec at `Clear_-_Exercise_Swap_Spec.md` contains all design decisions, API shapes, state management patterns, and acceptance criteria. Every task below references it. Read it fully before writing any code.
+
+---
+
+## Tasks
+
+### 1. Add Unified `group_id` to ExerciseStructure Types
+**Do:**
+- Open `src/types/generation.ts`
+- Add `group_id: string` to every non-standard variant of the `ExerciseStructure` union type:
+  - `superset` — add `group_id: string` (preserve existing `paired_with`)
+  - `circuit` — add `group_id: string` (preserve existing `circuit_id`)
+  - `emom` — add `group_id: string`
+  - `amrap` — add `group_id: string`
+  - `afap` — add `group_id: string`
+  - `timed` — add `group_id: string`
+  - `standard` — does NOT get `group_id`
+- Update type guards if they need to account for `group_id`
+- Update the workout generation prompt to assign `group_id` to all exercises within grouped structures (same ID for exercises in the same group)
+- Fix any resulting TypeScript errors across the codebase
+
+**Acceptance:**
+- [ ] All non-standard `ExerciseStructure` variants have `group_id: string`
+- [ ] `standard` does NOT have `group_id`
+- [ ] Existing fields (`paired_with`, `circuit_id`) preserved for backward compatibility
+- [ ] Workout generation prompt assigns `group_id` to grouped exercises
+- [ ] TypeScript compiles with no errors (`npx tsc --noEmit`)
+
+---
+
+### 2. Create `generate-section` Edge Function
+**Do:**
+- Create a NEW Supabase Edge Function at `supabase/functions/generate-section/index.ts`
+- Do NOT modify the existing `generate-workout` edge function
+- Add support for three swap modes: `swap_mode` ('section' | 'single' | 'unit'), `swap_target`, and `keep_exercises`
+- Implement three prompt variations based on `swap_mode` (see spec → API Design → Prompt Strategy for exact prompt text):
+  - `single` — replace one exercise, context of what stays
+  - `single` within circuit — replace one exercise, context of other circuit exercises
+  - `unit` — replace entire group (superset/EMOM/AMRAP/afap/timed), maintain structure type
+- Validate that the AI response maintains the correct structure type for unit swaps
+- Ensure response includes `group_id` on all non-standard exercises
+- Add request/response type definitions
+
+**Acceptance:**
+- [ ] New edge function exists at `supabase/functions/generate-section/index.ts`
+- [ ] Existing `generate-workout` edge function is NOT modified
+- [ ] Single swap mode returns a full section with one exercise replaced
+- [ ] Unit swap mode returns a full section with the group replaced, same structure type
+- [ ] Circuit swap includes other circuit exercises in prompt context
+- [ ] Response includes `group_id` on all non-standard exercises
+- [ ] Request types updated in TypeScript
+
+**Update:** `PROJECT_MAP.md` if edge function structure changes
+
+---
+
+### 3. Remove "Randomize Section" Button
+**Do:**
+- Open `src/components/WorkoutSectionCard.tsx`
+- Remove the `onRandomize` prop from the `WorkoutSectionCardProps` interface
+- Remove the `RefreshCw` icon import (if no longer used elsewhere)
+- Remove the "Randomize Section" button JSX and its click handler
+- Clean up parent components that pass the `onRandomize` prop (find all usages and remove the prop)
+- Do NOT remove the underlying API call logic — we'll reuse it for the swap feature
+
+**Acceptance:**
+- [ ] No "Randomize Section" button visible on any section card
+- [ ] `onRandomize` prop removed from `WorkoutSectionCardProps` interface
+- [ ] `RefreshCw` import cleaned up if unused
+- [ ] Parent components no longer pass `onRandomize`
+- [ ] No console errors or broken layouts from removal
+- [ ] Underlying section generation API utility still exists and is importable
+
+---
+
+### 4. Add Swap State Management
+**Do:**
+- Create swap state tracking alongside the existing `generatedWorkout` state (or equivalent) in the Review screen
+- Implement the `SwapSlot` and `SwapState` interfaces from the spec:
+  ```typescript
+  interface SwapSlot {
+    current: GeneratedExercise | GeneratedExercise[];
+    history: (GeneratedExercise | GeneratedExercise[])[];
+    swapCount: number;
+  }
+  ```
+- State is keyed by section type + exercise index (for single) or section type + group ID (for unit)
+- Note: index-based keying is safe because exercises do not reorder during preview
+- Implement helper functions:
+  - `performSwap(sectionType, targetIndex, newExercise)` — updates workout state, pushes old exercise to history, increments counter
+  - `performUnitSwap(sectionType, groupId, newExercises)` — same but for grouped exercises, uses `group_id` to find all members of the target group
+  - `revertToPrevious(sectionType, targetIndex)` — cycles backward through history, no API call
+- History capped at 3 entries per slot (oldest drops off)
+- Nothing persists to database — all in-memory until "Start Workout"
+
+**Acceptance:**
+- [ ] Swap state initializes empty when workout loads
+- [ ] `performSwap` updates the correct exercise and tracks history
+- [ ] `performUnitSwap` uses `group_id` to find and update all exercises in a group
+- [ ] `revertToPrevious` restores the prior exercise without API call
+- [ ] History stays capped at 3
+- [ ] Swap counter increments correctly
+
+---
+
+### 5. Single Exercise Swap UI
+**Do:**
+- Add a swap icon (↻) inside expanded exercise details on exercises with `structure.type === 'standard'`
+- Add the same swap icon on individual exercises inside circuits (`structure.type === 'circuit'`)
+- Icon is ONLY visible when the exercise card is expanded — not visible in collapsed state
+- Icon spec: 16-20px icon, 44×44px touch target, muted color default, primary on hover/tap
+- Use design tokens for all colors — no hardcoded values
+- On tap:
+  1. Disable icon, show placeholder loading state (dim card to opacity 0.5, spinner replaces swap icon)
+  2. Call the new `generate-section` edge function with `swap_mode: 'single'`, exercise context, and `keep_exercises`
+  3. Extract replacement exercise from response
+  4. Call `performSwap()` to update state
+  5. Card updates with new exercise
+- Debounce: 2-second minimum between swap calls per slot
+- On error: show inline error on card, preserve existing exercise, do not count toward swap limit
+- After first swap on a slot, show "← Previous" button next to swap icon
+- "Previous" taps call `revertToPrevious()` — no API call, cycles through history
+- After 3 swaps: disable swap icon, fire informational toast: "Nothing feeling right? Try regenerating with different inputs." with "Regenerate Workout" action that navigates to Screen 1 with current settings pre-filled
+- Toast auto-dismisses after standard duration; swap icon stays disabled
+- Use existing toast component with informational variant
+
+**Acceptance:**
+- [ ] Swap icon visible only inside expanded details on standard + circuit exercises
+- [ ] Swap icon hidden on collapsed cards
+- [ ] Swap icon hidden on superset/EMOM/AMRAP/afap/timed exercises (these use unit swap)
+- [ ] Tapping swap triggers API call to `generate-section` with full context
+- [ ] Only the targeted exercise updates
+- [ ] Loading state: card dims, spinner on icon
+- [ ] Error preserves existing exercise
+- [ ] "Previous" button appears after first swap
+- [ ] Previous cycles through history without API calls
+- [ ] After 3 swaps: icon disabled + informational toast shown
+- [ ] Touch target ≥ 44px
+- [ ] All styling uses design tokens
+
+---
+
+### 6. Unit Swap UI
+**Do:**
+- For superset groups: add one swap icon labeled "Swap Pair" on the expanded superset container
+- For EMOM/AMRAP/afap/timed blocks: add one swap icon labeled "Swap Block" on the expanded block container
+- Icon placement: bottom of the expanded group, same style as single swap icon
+- On tap:
+  1. Dim all cards in the group, show spinner on the group container
+  2. Call the new `generate-section` edge function with `swap_mode: 'unit'`, group context
+  3. Extract replacement group from response
+  4. Call `performUnitSwap()` to update state — keyed off `group_id`
+  5. All cards in the group update together
+- Same swap limit (3), history, previous, and toast behavior as single swap — but tracked per group, not per exercise within the group
+- Debounce: 2-second minimum
+
+**Acceptance:**
+- [ ] Superset pairs show "Swap Pair" icon on expanded group
+- [ ] EMOM/AMRAP/afap/timed blocks show "Swap Block" icon on expanded group
+- [ ] No individual swap icons on exercises within these groups
+- [ ] Tapping swap replaces the entire unit
+- [ ] AI returns replacement with same structure type
+- [ ] All cards in the group update together
+- [ ] Loading state dims all group cards
+- [ ] Swap limit + history + previous work per group
+
+---
+
+### 7. Verify Edge Cases
+**Do:**
+- Test: Section with one standard exercise (swap icon appears, works normally)
+- Test: Section that is entirely one EMOM block (unit swap = full section replacement)
+- Test: Circuit with 4 exercises, swap one — other 3 unchanged
+- Test: Swap 3 times on same slot → icon disables, toast fires
+- Test: Use "Previous" to cycle back through all 3 history entries
+- Test: Error during swap → exercise preserved, counter not incremented
+- Test: Rapid tapping swap → debounce prevents multiple API calls
+- Test: `group_id` correctly identifies all members of a group across structure types
+- Test on mobile viewport — touch targets ≥ 44px, no layout shifts during loading
+
+**Acceptance:**
+- [ ] All edge cases pass
+- [ ] `group_id` grouping works correctly for all structure types
+- [ ] No layout shifts or broken states
+- [ ] Mobile-friendly
+
+---
+
+## Design System Compliance
+- Use tokens from `design-tokens.json` — no hardcoded colors, spacing, or font values
+- Match existing exercise card patterns and component structure
+- Toast uses existing toast component with informational variant
+- Icons use existing icon system/library
+- Mobile-first: all touch targets ≥ 44px
+
+## After Session (REQUIRED — you are not done until this is complete)
+- [ ] Update `SESSION_LOG.md` with: Date, Tasks Completed, Files Touched
+- [ ] Update `PROJECT_MAP.md` if architecture changed (edge function extension, new state patterns)
+- [ ] Add to `BACKLOG.md`: "Exercise Swap Phase B — multi-select edit mode" (if not already there)
+- [ ] Mark completed items as `[x]` in `BACKLOG.md`
+- [ ] Confirm: "Session complete. Log and Backlog updated. Ready for next plan."

--- a/.claude/plans/SESSION_PLAN_loading_screens.md
+++ b/.claude/plans/SESSION_PLAN_loading_screens.md
@@ -1,0 +1,356 @@
+# Session Plan: Loading Screen Component
+
+## Session Goal
+Build and integrate three loading screen variants (boot, fullscreen overlay, card loader) using the approved scan line + character noise design pattern.
+
+## Context
+- **Spec:** This document + `clear-loading-screen-prototype.html` (reference implementation)
+- **Figma:** N/A — design approved via prototype
+- **Current state:** `src/pages/Index.tsx` renders a `'loading'` screen state with no implementation (placeholder). Exercise swap loading state is explicitly flagged as a placeholder in `Clear_-_Exercise_Swap_Spec.md`.
+- **Related specs:** `Clear_-_Exercise_Swap_Spec.md` (card loader replaces the dim+spinner placeholder)
+
+---
+
+## Background: Three Variants
+
+All three share the same design language — orange (#F87823 / `--color-orange-500`) scan line, character noise grid, dark background — scoped differently per use case.
+
+| Variant | Logo | Message | Behavior | Used For |
+|---|---|---|---|---|
+| `boot` | Yes | Status sequence (up to 5 messages) | Plays sweeps until `ready`, then exits cleanly | App launch / auth check |
+| `fullscreen` | No | Single contextual string | Bidirectional loop until dismissed | Workout generation |
+| `card` | No | None | Fills card, sweeps, reveals content | Exercise swap |
+
+The prototype (`clear-loading-screen-prototype.html`) is the visual source of truth. Port the canvas logic directly — don't redesign.
+
+---
+
+## Tasks
+
+### 1. Create `<ScanLoader>` base component
+
+**Do:**
+Create `src/components/ScanLoader/ScanLoader.tsx` with the shared canvas engine. This is the core — variants compose on top of it.
+
+Props interface:
+```typescript
+interface ScanLoaderProps {
+  // Canvas container — component fills its parent's bounds
+  width?: number;   // defaults to 100% of parent
+  height?: number;  // defaults to 100% of parent
+
+  // Scan behavior
+  direction?: 'down-once' | 'bounce'; // 'down-once' for boot, 'bounce' for fullscreen
+  running: boolean;                    // controls animation start/stop
+  onComplete?: () => void;             // fires when direction='down-once' finishes
+}
+```
+
+Implementation notes from prototype:
+- Canvas characters: `'01ABCDEFGHIJKLMNOPQRSTUVWXYZ@#$%!?><|~-_+=:;'`
+- Cell size: 11px wide x 15px tall
+- Character opacity: `0.04-0.14` range, flicker at 90.5-99% frame survival rate
+- Scan line: 2px `#F87823` stroke + multi-layer glow (14px shadow blur, 4px core blur)
+- Noise clears on the trailing side of scan direction
+- Easing: ease-in-out-quad on scan position
+- Bounce: re-seed grid on direction flip so fresh noise appears ahead of returning scan
+- Subtle CRT scanline overlay: `rgba(0,0,0,0.04)` every 3px vertically
+
+**Use tokens, not hardcoded values:**
+```css
+/* In component or via Tailwind */
+--color-orange-500: #F87823   /* scan line + noise color */
+--color-neutral-900: #171717  /* background */
+--color-neutral-50: #F1F1F1   /* logo text */
+```
+
+**Acceptance:**
+- [ ] Canvas fills parent container
+- [ ] `running=false` -> canvas is blank
+- [ ] `running=true, direction='down-once'` -> single downward sweep, `onComplete` fires
+- [ ] `running=true, direction='bounce'` -> continuous up/down loop
+- [ ] Scan line glow matches prototype visually
+- [ ] No hardcoded color values — uses CSS custom properties or token references
+- [ ] Handles `ResizeObserver` — canvas redraws correctly when container resizes
+
+---
+
+### 2. Create `<BootScreen>` component
+
+**Do:**
+Create `src/components/ScanLoader/BootScreen.tsx`.
+
+```typescript
+interface BootScreenProps {
+  ready: boolean;        // true once auth/data has resolved
+  onComplete: () => void; // called when boot animation is done — navigate to next screen
+}
+```
+
+Layout (full screen, fixed position, z-index above everything):
+- `<ScanLoader direction="down-once" running={true} onComplete={handleSweepComplete} />`
+- CLEAR logo centered — static, Oxanium 700, `clamp(52px, 12vw, 80px)`
+- Orange scan line rule across logo at 57% vertical height (static decoration, not the canvas scan line)
+- Status message below logo — typewriter effect, 42ms per character
+- Progress bar + percentage — bottom center, `min(260px, 65vw)` wide, 1px track
+
+Status message sequence (one per sweep, shown in order as sweeps play):
+1. `AUTHENTICATING USER`
+2. `LOADING TRAINING HISTORY`
+3. `CALIBRATING INTENSITY`
+4. `GENERATING WORKOUT`
+5. `SYSTEM READY`
+
+**Interruptible behavior:**
+- The boot sequence does NOT require all 5 sweeps to complete
+- When `ready` becomes true mid-sweep, finish the CURRENT sweep so the scan line exits cleanly (no sharp visual jump), then fire `onComplete()` immediately
+- If `ready` is already true when BootScreen mounts, still play at least one full sweep for visual continuity before firing `onComplete()`
+- Status messages advance in order as sweeps play, but stop advancing once `ready` triggers early exit
+- Progress bar: if exiting early, snap to 100% on the final sweep before calling `onComplete()`
+
+**Acceptance:**
+- [ ] Full screen, renders above all other content
+- [ ] Logo visible and centered throughout
+- [ ] Each sweep triggers the next status message (typewriter)
+- [ ] Progress bar advances proportionally across played sweeps
+- [ ] When `ready` is true, current sweep finishes cleanly, then `onComplete` fires
+- [ ] If `ready` is true on mount, at least one full sweep plays before `onComplete`
+- [ ] Progress bar snaps to 100% on the final (exit) sweep
+- [ ] `onComplete` never fires before a sweep finishes — no mid-animation jumps
+- [ ] Correct fonts: Oxanium for logo + messages, monospace for noise
+
+---
+
+### 3. Create `<FullscreenLoader>` component
+
+**Do:**
+Create `src/components/ScanLoader/FullscreenLoader.tsx`.
+
+```typescript
+interface FullscreenLoaderProps {
+  message: string;     // e.g. 'GENERATING WORKOUT' or 'LOADING'
+  visible: boolean;    // controls show/hide
+  onDismiss?: () => void; // optional — if provided, shows close affordance (dev/debug only)
+}
+```
+
+Layout (full screen, fixed, z-index above everything):
+- `<ScanLoader direction="bounce" running={visible} />`
+- Message string centered — same position as BootScreen message — typewriter on mount, then static
+- No logo, no progress bar
+- No close button in production — `onDismiss` is for dev use only
+- Dismissed programmatically by parent setting `visible={false}`
+
+**Acceptance:**
+- [ ] Full screen when `visible=true`, unmounts (or `display:none`) when `visible=false`
+- [ ] Scan line bounces continuously while visible
+- [ ] Message types in once on mount, stays static
+- [ ] Removing `visible` stops animation cleanly — no orphaned rAF loops
+- [ ] `running` prop correctly pauses canvas when not visible (performance)
+
+---
+
+### 4. Create `<CardLoader>` component
+
+**Do:**
+Create `src/components/ScanLoader/CardLoader.tsx`.
+
+```typescript
+interface CardLoaderProps {
+  running: boolean;      // true = start the fill->sweep sequence
+  onSweepComplete: () => void; // fire at the moment the scan line exits the bottom
+                               // parent swaps content here, THEN CardLoader fades out
+}
+```
+
+Sequence (reference prototype for timing):
+1. **Fill phase** (200ms): Noise fades in over the card
+2. **Sweep phase** (750ms): Scan line sweeps top -> bottom, clearing noise
+3. At sweep complete: fire `onSweepComplete()` — parent updates content in DOM
+4. **Fade phase** (260ms): Canvas fades out, revealing new content beneath
+
+Component renders as `position: absolute; inset: 0` — it overlays its parent card. Parent card needs `position: relative; overflow: hidden`.
+
+No noise re-seed between phases — this is a single one-way pass. Content reveal is the payoff.
+
+**Acceptance:**
+- [ ] Fills parent bounds via absolute positioning
+- [ ] `running=false` -> invisible (opacity 0, pointer-events none)
+- [ ] `running=true` -> fill -> sweep -> `onSweepComplete()` fires -> fade out
+- [ ] Parent content update happens between sweep complete and fade-out (content visible after canvas clears)
+- [ ] Card height does NOT shift during animation — layout stable throughout
+- [ ] Re-triggerable: `running` can go true -> false -> true for repeated swaps
+- [ ] Canvas teardown is clean — no rAF loops running when `running=false`
+
+---
+
+### 5. Wire `BootScreen` into route guards
+
+**Do:**
+Replace the `<LoadingScreen>` placeholder in `src/routes/guards.tsx` with `<BootScreen>`.
+
+The three route guard components (`ProtectedRoute`, `PublicOnlyRoute`, `OnboardingRoute`) each currently render `<LoadingScreen subtitle="Initializing..." />` when `status === 'loading'`. The BootScreen should replace `<LoadingScreen>` in these guards — at minimum in `ProtectedRoute`, which is the main entry point.
+
+The `ready` prop maps to `status !== 'loading'` (auth resolved). `onComplete` triggers the existing routing logic — the guard already handles redirect, so BootScreen just delays it visually until the animation finishes.
+
+```typescript
+// In ProtectedRoute (src/routes/guards.tsx):
+const { status, profile } = useAuthContext();
+const [bootComplete, setBootComplete] = useState(false);
+
+// Show boot screen while loading OR while boot animation hasn't finished
+if (status === 'loading' || !bootComplete) {
+  return (
+    <BootScreen
+      ready={status !== 'loading'}
+      onComplete={() => setBootComplete(true)}
+    />
+  );
+}
+
+// After boot completes, existing routing logic runs:
+if (status === 'unauthenticated') {
+  return <Navigate to="/welcome" replace />;
+}
+// ...etc
+```
+
+For `PublicOnlyRoute` and `OnboardingRoute`, keep `<LoadingScreen>` or use a simpler treatment — the boot sequence is primarily for the main app entry.
+
+**Acceptance:**
+- [ ] App launch shows boot sequence in `ProtectedRoute`
+- [ ] Boot animation plays until `ready` becomes true, then finishes current sweep and fires `onComplete`
+- [ ] If auth resolves quickly, at least one full sweep plays
+- [ ] After `onComplete`, guard proceeds with normal routing (redirect or render outlet)
+- [ ] No regression to existing auth flow
+- [ ] `PublicOnlyRoute` and `OnboardingRoute` still show a loading state (either BootScreen or existing LoadingScreen)
+
+---
+
+### 6. Wire `FullscreenLoader` into workout generation flow
+
+**Do:**
+In `src/pages/GenerationScreen.tsx`, show `<FullscreenLoader message="GENERATING WORKOUT" />` while `isGenerating === true`. The `isGenerating` state is consumed at line 18 from `useWorkoutFlowContext()` and currently only drives the `GenerateButton` loading state.
+
+The FullscreenLoader should render in `GenerationScreen.tsx` alongside the existing content, overlaying the generation form while the API call is in progress.
+
+```typescript
+// In GenerationScreen.tsx:
+import { FullscreenLoader } from "@/components/ScanLoader";
+
+// ... existing component code ...
+
+return (
+  <AppLayout
+    header={<PageHeader ... />}
+    footer={<GenerateButton onClick={handleGenerate} disabled={!canGenerate} isLoading={isGenerating} />}
+  >
+    <div className="pt-6 space-y-6 stagger-reveal">
+      {/* ...existing form fields... */}
+    </div>
+
+    <FullscreenLoader
+      message="GENERATING WORKOUT"
+      visible={isGenerating}
+    />
+  </AppLayout>
+);
+```
+
+**Acceptance:**
+- [ ] FullscreenLoader appears immediately when generation starts (`isGenerating` becomes true)
+- [ ] FullscreenLoader disappears when generation completes (or errors) — `isGenerating` becomes false
+- [ ] FullscreenLoader renders above the generation form content
+- [ ] Error state: loader hides, error handling proceeds normally
+
+---
+
+### 7. Wire `CardLoader` into exercise swap
+
+**Do:**
+Replace the existing opacity-dim loading pattern in `src/components/ExerciseCard.tsx` and `src/components/WorkoutSectionCard.tsx` with `<CardLoader>`.
+
+Currently:
+- `ExerciseCard.tsx` (line 41): `opacity: isSwapLoading ? 0.5 : 1` — dims the entire card when `isSwapLoading` is true
+- `WorkoutSectionCard.tsx` (line 163): `opacity: isLoading ? 0.5 : 1` — dims grouped exercises when `isSwapLoading` is true on the group controls
+
+CardLoader replaces this `opacity: 0.5` dim pattern in both components:
+
+```typescript
+// In ExerciseCard.tsx — replace the opacity dim wrapper:
+<div style={{ position: 'relative', overflow: 'hidden' }}>
+  {/* ...existing exercise card content... */}
+  <CardLoader
+    running={isSwapLoading}
+    onSweepComplete={() => {
+      // Content update happens via parent state — CardLoader just provides the visual transition
+    }}
+  />
+</div>
+
+// In WorkoutSectionCard.tsx — replace the opacity dim on grouped exercises:
+<div
+  key={`group-${group.groupId || groupIdx}`}
+  style={{ position: 'relative', overflow: 'hidden' }}
+>
+  {/* ...existing group content... */}
+  <CardLoader
+    running={isLoading}
+    onSweepComplete={() => {
+      // Content update happens via parent state
+    }}
+  />
+</div>
+```
+
+**Acceptance:**
+- [ ] Swap tap triggers CardLoader instead of opacity dim in ExerciseCard (`isSwapLoading` prop)
+- [ ] Group swap triggers CardLoader instead of opacity dim in WorkoutSectionCard (`isLoading` from `groupControls?.isSwapLoading`)
+- [ ] Noise fills card, scan sweeps, content updates, canvas fades out
+- [ ] New exercise content revealed cleanly
+- [ ] Card height stable throughout
+- [ ] No remaining `opacity: 0.5` swap loading patterns
+
+---
+
+## Design System Compliance
+- Use CSS custom properties from `src/index.css` — no hardcoded hex values
+- Fonts: `font-family: 'Oxanium'` for UI text (already loaded), monospace for noise characters
+- All spacing and sizing via Tailwind tokens where possible
+- No new dependencies — canvas API only, no animation libraries
+
+## Prototype Reference
+`clear-loading-screen-prototype.html` — port canvas logic directly. The prototype is vanilla JS; translate to React using `useRef` for the canvas element and `useEffect` for the animation loop. Use `useRef` for rAF handle to ensure cleanup on unmount.
+
+```typescript
+// Pattern for rAF cleanup in React:
+const rafRef = useRef<number>();
+useEffect(() => {
+  // start loop
+  rafRef.current = requestAnimationFrame(frame);
+  return () => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+  };
+}, [running]);
+```
+
+---
+
+## File Structure After This Session
+
+```
+src/components/ScanLoader/
+--- ScanLoader.tsx        <- canvas engine (Tasks 1)
+--- BootScreen.tsx        <- boot variant (Task 2)
+--- FullscreenLoader.tsx  <- fullscreen variant (Task 3)
+--- CardLoader.tsx        <- card variant (Task 4)
+--- index.ts              <- barrel export
+```
+
+---
+
+## After Session (REQUIRED — you are not done until this is complete)
+- [ ] Update `SESSION_LOG.md` with: Date, Tasks Completed, Files Touched
+- [ ] Update `PROJECT_MAP.md`: add `src/components/ScanLoader/` to component directory
+- [ ] Note in `Clear_-_Exercise_Swap_Spec.md`: loading placeholder replaced by `<CardLoader>`
+- [ ] Confirm: "Session complete. Log and Backlog updated. Ready for next plan."

--- a/docs/prototypes/clear-loading-screen-prototype.html
+++ b/docs/prototypes/clear-loading-screen-prototype.html
@@ -1,0 +1,399 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CLEAR — Loading Screen Variants</title>
+<link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@500;700&family=Rajdhani:wght@700&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { background: #171717; min-height: 100vh; font-family: 'Oxanium', monospace; color: #F1F1F1; }
+
+  .shell { padding: 48px 32px; max-width: 900px; margin: 0 auto; }
+  .shell-label { font-size: 9px; letter-spacing: .3em; color: rgba(248,120,35,.45); text-transform: uppercase; margin-bottom: 48px; }
+  .section { margin-bottom: 56px; }
+  .section-title { font-family: 'Rajdhani', sans-serif; font-size: 11px; letter-spacing: .2em; color: rgba(241,241,241,.3); text-transform: uppercase; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid rgba(255,255,255,.05); }
+  .hint { font-size: 10px; letter-spacing: .14em; color: rgba(241,241,241,.22); line-height: 1.9; margin-top: 12px; }
+  .btn-row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 4px; }
+  .dbtn { font-family: 'Oxanium', monospace; font-size: 10px; letter-spacing: .24em; color: rgba(248,120,35,.65); background: transparent; border: 1px solid rgba(248,120,35,.22); padding: 10px 18px; cursor: pointer; text-transform: uppercase; transition: all .18s; }
+  .dbtn:hover { color: #F87823; border-color: rgba(248,120,35,.55); }
+
+  .card-row { display: flex; gap: 16px; flex-wrap: wrap; }
+  .mock-card { background: rgba(248,120,35,.06); border: 1px solid rgba(248,120,35,.2); padding: 20px; width: 260px; position: relative; overflow: hidden; min-height: 110px; }
+  .card-canvas { position: absolute; inset: 0; z-index: 2; pointer-events: none; opacity: 0; }
+  .ex-name { font-family: 'Rajdhani', sans-serif; font-size: 16px; font-weight: 700; letter-spacing: .05em; color: #F1F1F1; margin-bottom: 6px; }
+  .ex-meta { font-size: 10px; letter-spacing: .18em; color: rgba(248,120,35,.65); }
+  .ex-detail { font-size: 9px; letter-spacing: .14em; color: rgba(241,241,241,.3); margin-top: 6px; }
+
+  #overlay { display: none; position: fixed; inset: 0; z-index: 200; background: #171717; }
+  #ov-canvas { position: absolute; inset: 0; }
+  #ov-ui { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; pointer-events: none; }
+  #ov-logo { font-weight: 700; font-size: clamp(52px, 12vw, 80px); letter-spacing: .18em; color: #F1F1F1; position: relative; line-height: 1; text-transform: uppercase; }
+  #ov-logoline { position: absolute; left: -12%; right: -12%; height: 2px; top: 57%; background: #F87823; box-shadow: 0 0 8px rgba(248,120,35,.9), 0 0 20px rgba(248,120,35,.4), 0 0 40px rgba(248,120,35,.15); }
+  #ov-msg { margin-top: 28px; font-weight: 500; font-size: 11px; letter-spacing: .32em; color: #F87823; text-transform: uppercase; min-height: 18px; }
+  #ov-footer { position: absolute; bottom: 52px; left: 50%; transform: translateX(-50%); width: min(260px,65vw); }
+  #ov-pct { font-size: 9px; letter-spacing: .3em; color: rgba(248,120,35,.4); text-align: right; margin-bottom: 6px; }
+  #ov-track { height: 1px; background: rgba(248,120,35,.1); }
+  #ov-fill { height: 100%; background: #F87823; width: 0%; box-shadow: 0 0 6px rgba(248,120,35,.7); transition: width .08s linear; }
+  #ov-close { position: absolute; bottom: 36px; right: 36px; font-family: 'Oxanium', monospace; font-size: 9px; letter-spacing: .28em; color: rgba(248,120,35,.55); background: transparent; border: 1px solid rgba(248,120,35,.2); padding: 10px 16px; cursor: pointer; text-transform: uppercase; transition: all .2s; display: none; }
+  #ov-close:hover { color: #F87823; border-color: rgba(248,120,35,.5); }
+</style>
+</head>
+<body>
+
+<div id="overlay">
+  <canvas id="ov-canvas"></canvas>
+  <div id="ov-ui">
+    <div id="ov-logo" style="display:none">CLEAR<div id="ov-logoline"></div></div>
+    <div id="ov-msg"></div>
+  </div>
+  <div id="ov-footer" style="display:none">
+    <div id="ov-pct">0%</div>
+    <div id="ov-track"><div id="ov-fill"></div></div>
+  </div>
+  <button id="ov-close">✕ CLOSE</button>
+</div>
+
+<div class="shell">
+  <div class="shell-label">Clear — Loading Screen / Variants Prototype</div>
+
+  <div class="section">
+    <div class="section-title">01 — Boot / Splash &nbsp;·&nbsp; full screen · with logo · plays once</div>
+    <div class="btn-row">
+      <button class="dbtn" onclick="runBoot()">▶ Play Boot Sequence</button>
+    </div>
+    <div class="hint">Plays on app launch during auth check.<br>5 sweeps downward with status messages. Progress bar. ~10s total.</div>
+  </div>
+
+  <div class="section">
+    <div class="section-title">02 — Fullscreen Overlay &nbsp;·&nbsp; no logo · bidirectional · loops until ready</div>
+    <div class="btn-row">
+      <button class="dbtn" onclick="runFullscreen('GENERATING WORKOUT')">▶ Generating Workout</button>
+      <button class="dbtn" onclick="runFullscreen('LOADING')">▶ Generic</button>
+    </div>
+    <div class="hint">Scan line bounces up and down, noise fills ahead of it and clears behind.<br>Loops indefinitely. ✕ CLOSE simulates content ready.</div>
+  </div>
+
+  <div class="section">
+    <div class="section-title">03 — Card Loader &nbsp;·&nbsp; contained · clears to reveal new content</div>
+    <div class="btn-row">
+      <button class="dbtn" onclick="runCard('ca')">▶ Swap Card A</button>
+      <button class="dbtn" onclick="runCard('cb')">▶ Swap Card B</button>
+    </div>
+    <div class="card-row">
+      <div class="mock-card" id="ca">
+        <canvas class="card-canvas" id="ca-canvas"></canvas>
+        <div id="ca-content">
+          <div class="ex-name">BARBELL ROW</div>
+          <div class="ex-meta">4 × 8 &nbsp;·&nbsp; 65% &nbsp;·&nbsp; REST 90s</div>
+          <div class="ex-detail">Last: 135–155 lbs</div>
+        </div>
+      </div>
+      <div class="mock-card" id="cb">
+        <canvas class="card-canvas" id="cb-canvas"></canvas>
+        <div id="cb-content">
+          <div class="ex-name">ARM CIRCLES</div>
+          <div class="ex-meta">1 × 10 &nbsp;·&nbsp; EACH DIRECTION</div>
+          <div class="ex-detail">Bodyweight</div>
+        </div>
+      </div>
+    </div>
+    <div class="hint">Noise fills the card, scan sweeps down, clears to reveal new exercise.<br>Tap repeatedly to keep swapping.</div>
+  </div>
+</div>
+
+<script>
+// ─── shared ───────────────────────────────────────────────
+const CHARS = '01ABCDEFGHIJKLMNOPQRSTUVWXYZ@#$%!?><|~-_+=:;';
+const CW = 11, CH = 15;
+
+function makeGrid(cols, rows) {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({
+      ch: CHARS[Math.random() * CHARS.length | 0],
+      op: .04 + Math.random() * .10,
+      fr: .905 + Math.random() * .085,
+    }))
+  );
+}
+
+// Draw noise. Clears on the "trailing" side of scanY based on direction.
+// dir=1 → sweeping down (noise below scanY, clear above)
+// dir=-1 → sweeping up (noise above scanY, clear below)
+function drawNoise(ctx, grid, scanY, cols, rows, dir = 1, globalAlpha = 1) {
+  ctx.font = `bold ${CH * .70 | 0}px 'Courier New', monospace`;
+  for (let r = 0; r < rows; r++) {
+    const cy   = r * CH;
+    const dist = dir === 1 ? cy - scanY : scanY - cy; // positive = in "noise zone"
+    if (dist < -CH) continue; // fully cleared — skip
+    for (let c = 0; c < cols; c++) {
+      const cell = grid[r][c];
+      if (Math.random() > cell.fr) cell.ch = CHARS[Math.random() * CHARS.length | 0];
+      const fadeIn = Math.min(dist / 32, 1);
+      const prox   = Math.max(0, 1 - Math.abs(dist) / 60) * .06;
+      const a      = (cell.op + prox) * Math.max(0, fadeIn) * globalAlpha;
+      if (a < .004) continue;
+      ctx.fillStyle = `rgba(248,120,35,${a.toFixed(3)})`;
+      ctx.fillText(cell.ch, c * CW, cy + CH * .76);
+    }
+  }
+}
+
+function drawScanLine(ctx, scanY, width, height) {
+  if (scanY < -4 || scanY > height + 4) return;
+  const g = ctx.createLinearGradient(0, scanY - 12, 0, scanY + 12);
+  g.addColorStop(0,  'rgba(248,120,35,0)');
+  g.addColorStop(.5, 'rgba(248,120,35,.15)');
+  g.addColorStop(1,  'rgba(248,120,35,0)');
+  ctx.fillStyle = g; ctx.fillRect(0, scanY - 12, width, 24);
+  ctx.save();
+  ctx.shadowColor = 'rgba(248,120,35,.7)'; ctx.shadowBlur = 14;
+  ctx.beginPath(); ctx.moveTo(0, scanY); ctx.lineTo(width, scanY);
+  ctx.strokeStyle = '#F87823'; ctx.lineWidth = 2; ctx.stroke();
+  ctx.shadowBlur = 4;
+  ctx.beginPath(); ctx.moveTo(0, scanY); ctx.lineTo(width, scanY);
+  ctx.strokeStyle = 'rgba(255,205,130,.7)'; ctx.lineWidth = .7; ctx.stroke();
+  ctx.restore();
+}
+
+function ease(p) { return p < .5 ? 2*p*p : 1 - Math.pow(-2*p+2, 2)/2; }
+
+
+// ─── variant 1: boot (one-directional, plays once) ────────
+// ─── variant 2: fullscreen overlay (bidirectional, loops) ─
+const overlay  = document.getElementById('overlay');
+const ovCanvas = document.getElementById('ov-canvas');
+const ovCtx    = ovCanvas.getContext('2d');
+const ovLogo   = document.getElementById('ov-logo');
+const ovMsg    = document.getElementById('ov-msg');
+const ovFooter = document.getElementById('ov-footer');
+const ovPct    = document.getElementById('ov-pct');
+const ovFill   = document.getElementById('ov-fill');
+const ovClose  = document.getElementById('ov-close');
+
+const BOOT_MSGS = [
+  'AUTHENTICATING USER',
+  'LOADING TRAINING HISTORY',
+  'CALIBRATING INTENSITY',
+  'GENERATING WORKOUT',
+  'SYSTEM READY',
+];
+const SWEEP_MS = 2000;
+
+let fsGrid, fsCols, fsRows;
+let fsRunning = false, fsScan = 0, fsT0 = null, fsSweep = 0;
+let fsMode = 'boot', fsSingleMsg = '';
+let fsDir = 1; // 1 = down, -1 = up (used by fullscreen looping mode)
+let fsTypeT = null;
+
+function fsResize() {
+  ovCanvas.width  = innerWidth;
+  ovCanvas.height = innerHeight;
+  fsCols = Math.ceil(ovCanvas.width  / CW) + 2;
+  fsRows = Math.ceil(ovCanvas.height / CH) + 2;
+  fsGrid = makeGrid(fsCols, fsRows);
+}
+
+function fsType(text) {
+  clearInterval(fsTypeT);
+  ovMsg.textContent = '';
+  let i = 0;
+  fsTypeT = setInterval(() => {
+    if (i < text.length) ovMsg.textContent = text.slice(0, ++i);
+    else clearInterval(fsTypeT);
+  }, 42);
+}
+
+function fsFrame(ts) {
+  if (!fsRunning) return;
+  if (fsT0 === null) {
+    fsT0 = ts;
+    if (fsMode === 'boot') fsType(BOOT_MSGS[fsSweep] || '');
+    else if (fsSweep === 0) fsType(fsSingleMsg); // type once, leave it
+  }
+
+  const p = Math.min((ts - fsT0) / SWEEP_MS, 1);
+  const e = ease(p);
+
+  // Boot: top → bottom only
+  // Fullscreen: alternates direction each sweep
+  if (fsMode === 'boot') {
+    fsScan = e * ovCanvas.height;
+  } else {
+    fsScan = fsDir === 1
+      ? e * ovCanvas.height          // 0 → bottom
+      : ovCanvas.height * (1 - e);   // bottom → 0
+  }
+
+  // Progress bar (boot only)
+  if (fsMode === 'boot') {
+    const tot = Math.min(((fsSweep + p) / BOOT_MSGS.length) * 100, 100);
+    ovFill.style.width = tot + '%';
+    ovPct.textContent  = Math.round(tot) + '%';
+  }
+
+  ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+  // Subtle CRT scanlines
+  ovCtx.fillStyle = 'rgba(0,0,0,.04)';
+  for (let y = 0; y < ovCanvas.height; y += 3) ovCtx.fillRect(0, y, ovCanvas.width, 1);
+
+  drawNoise(ovCtx, fsGrid, fsScan, fsCols, fsRows, fsMode === 'boot' ? 1 : fsDir);
+  drawScanLine(ovCtx, fsScan, ovCanvas.width, ovCanvas.height);
+
+  if (p >= 1) {
+    fsSweep++;
+    fsT0 = null;
+
+    if (fsMode === 'boot') {
+      if (fsSweep >= BOOT_MSGS.length) {
+        // Boot complete
+        fsRunning = false;
+        ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+        ovFill.style.width = '100%'; ovPct.textContent = '100%';
+        ovClose.style.display = 'block';
+        return;
+      }
+    } else {
+      // Fullscreen: flip direction and re-fill noise on the new "trailing" side
+      fsDir *= -1;
+      // Re-seed grid so there's always fresh noise ahead of the returning scan
+      fsGrid = makeGrid(fsCols, fsRows);
+    }
+  }
+
+  requestAnimationFrame(fsFrame);
+}
+
+function runBoot() {
+  fsResize();
+  fsMode = 'boot'; fsDir = 1; fsRunning = true; fsSweep = 0; fsT0 = null; fsScan = 0;
+  ovFill.style.width = '0%'; ovPct.textContent = '0%'; ovMsg.textContent = '';
+  ovLogo.style.display   = 'block';
+  ovFooter.style.display = 'block';
+  ovClose.style.display  = 'none';
+  overlay.style.display  = 'block';
+  requestAnimationFrame(fsFrame);
+}
+
+function runFullscreen(label) {
+  fsResize();
+  fsMode = 'fullscreen'; fsSingleMsg = label; fsDir = 1;
+  fsRunning = true; fsSweep = 0; fsT0 = null; fsScan = 0; ovMsg.textContent = '';
+  ovLogo.style.display   = 'none';
+  ovFooter.style.display = 'none';
+  ovClose.style.display  = 'block';
+  overlay.style.display  = 'block';
+  requestAnimationFrame(fsFrame);
+}
+
+ovClose.addEventListener('click', () => {
+  fsRunning = false;
+  overlay.style.display = 'none';
+  ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+});
+
+window.addEventListener('resize', () => {
+  if (overlay.style.display !== 'none') fsResize();
+});
+
+
+// ─── variant 3: card loader ───────────────────────────────
+const CARD_CONTENT = {
+  ca: [
+    { name: 'BARBELL ROW',         meta: '4 × 8 · 65% · REST 90s',       detail: 'Last: 135–155 lbs'  },
+    { name: 'CABLE SEATED ROW',    meta: '4 × 10 · MODERATE · REST 75s', detail: 'Last: 120 lbs'       },
+    { name: 'CHEST-SUPPORTED ROW', meta: '3 × 12 · RPE 7 · REST 60s',    detail: 'Last: 45 lbs / DB'  },
+  ],
+  cb: [
+    { name: 'ARM CIRCLES',    meta: '1 × 10 · EACH DIRECTION',        detail: 'Bodyweight'       },
+    { name: 'BAND PULL-APARTS', meta: '2 × 15 · EACH DIRECTION',      detail: 'Resistance band'  },
+    { name: 'SHOULDER CARs',  meta: '1 × 8 · EACH ARM · CONTROLLED',  detail: 'Bodyweight'       },
+  ],
+};
+const cardIdx     = { ca: 0, cb: 0 };
+const cardRunning = { ca: false, cb: false };
+
+function runCard(id) {
+  if (cardRunning[id]) return;
+  cardRunning[id] = true;
+
+  const card    = document.getElementById(id);
+  const canvas  = document.getElementById(id + '-canvas');
+  const content = document.getElementById(id + '-content');
+  const ctx2    = canvas.getContext('2d');
+  const rect    = card.getBoundingClientRect();
+  canvas.width  = rect.width;
+  canvas.height = rect.height;
+  canvas.style.opacity = '1';
+
+  const cols2 = Math.ceil(canvas.width  / CW) + 2;
+  const rows2 = Math.ceil(canvas.height / CH) + 2;
+  const grid2 = makeGrid(cols2, rows2);
+
+  const FILL_MS  = 200;
+  const SWEEP_C  = 750;
+  let phase = 'fill', t0c = null, fillStart = null;
+
+  function cardFrame(ts) {
+    if (phase === 'fill') {
+      // Fade noise in over the card
+      if (!fillStart) fillStart = ts;
+      const alpha = Math.min((ts - fillStart) / FILL_MS, 1);
+      ctx2.clearRect(0, 0, canvas.width, canvas.height);
+      ctx2.font = `bold ${CH * .70 | 0}px 'Courier New', monospace`;
+      for (let r = 0; r < rows2; r++) {
+        for (let c = 0; c < cols2; c++) {
+          const cell = grid2[r][c];
+          const a = cell.op * alpha;
+          if (a < .004) continue;
+          ctx2.fillStyle = `rgba(248,120,35,${a.toFixed(3)})`;
+          ctx2.fillText(cell.ch, c * CW, r * CH + CH * .76);
+        }
+      }
+      if (alpha >= 1) { phase = 'sweep'; t0c = null; }
+      requestAnimationFrame(cardFrame);
+      return;
+    }
+
+    if (phase === 'sweep') {
+      // Scan line sweeps downward, clearing noise → reveals new content beneath
+      if (!t0c) t0c = ts;
+      const p      = Math.min((ts - t0c) / SWEEP_C, 1);
+      const scanY2 = ease(p) * canvas.height;
+
+      ctx2.clearRect(0, 0, canvas.width, canvas.height);
+      drawNoise(ctx2, grid2, scanY2, cols2, rows2, 1);
+      drawScanLine(ctx2, scanY2, canvas.width, canvas.height);
+
+      if (p >= 1) {
+        // Swap content, then fade canvas out to reveal it
+        cardIdx[id] = (cardIdx[id] + 1) % CARD_CONTENT[id].length;
+        const src   = CARD_CONTENT[id][cardIdx[id]];
+        content.querySelector('.ex-name').textContent   = src.name;
+        content.querySelector('.ex-meta').textContent   = src.meta;
+        content.querySelector('.ex-detail').textContent = src.detail;
+
+        let fadeStart2 = null;
+        function fadeOut(ts2) {
+          if (!fadeStart2) fadeStart2 = ts2;
+          const fp = Math.min((ts2 - fadeStart2) / 260, 1);
+          canvas.style.opacity = (1 - fp).toFixed(3);
+          if (fp < 1) requestAnimationFrame(fadeOut);
+          else {
+            canvas.style.opacity = '0';
+            ctx2.clearRect(0, 0, canvas.width, canvas.height);
+            cardRunning[id] = false;
+          }
+        }
+        requestAnimationFrame(fadeOut);
+        return;
+      }
+      requestAnimationFrame(cardFrame);
+    }
+  }
+
+  requestAnimationFrame(cardFrame);
+}
+</script>
+</body>
+</html>

--- a/docs/specs/Clear_-_Exercise_Swap_Spec.md
+++ b/docs/specs/Clear_-_Exercise_Swap_Spec.md
@@ -1,0 +1,374 @@
+# Clear — Exercise Swap (Phase A)
+
+> **Status:** DRAFT — Awaiting review  
+> **Last Updated:** March 4, 2026  
+> **Purpose:** Spec for single-exercise swap and unit-swap on the Review screen (Screen 2)
+
+---
+
+## Overview
+
+Users can customize generated workouts before starting them. Phase A delivers context-aware exercise swapping on the Review screen:
+
+- **Single Exercise Swap** — Replace one exercise without touching the rest (standard + circuit exercises)
+- **Unit Swap** — Replace grouped exercises as a single unit (supersets, EMOM, AMRAP, afap/timed)
+- **Swap History** — Track up to 3 previous swaps per slot so users can go back
+
+The existing "Randomize Section" button is replaced by per-exercise (or per-group) swap icons inside expanded exercise details. This gives users granular control without the noise of a section-level CTA.
+
+**Out of scope (Phase B — backlog):** Multi-select edit mode, mid-workout swaps on Screen 3.
+
+---
+
+## User Stories
+
+**Single swap:** "I like this warm-up except for Arm Circles — my shoulder hates those. Give me something else for that one slot."
+
+**Unit swap:** "This superset pairing doesn't feel right. Give me a new pair that fits the same role."
+
+**Swap limit:** "I've swapped this three times and nothing feels right." → App nudges: "Consider regenerating the full workout with different inputs."
+
+---
+
+## Swap Behavior by Structure Type
+
+| Structure Type | Swap Behavior | Icon Placement |
+|----------------|---------------|----------------|
+| Standard | Individual exercise swap | Swap icon on each exercise |
+| Superset | Swap the pair as a unit | One swap icon on the superset group |
+| Circuit | Individual swap within circuit (AI gets context of other circuit exercises) | Swap icon on each exercise inside the circuit |
+| EMOM | Swap the entire block as a unit | One swap icon on the EMOM group |
+| AMRAP | Swap the entire block as a unit | One swap icon on the AMRAP group |
+| For Time (afap) / Timed | Swap the entire block as a unit | One swap icon on the group |
+
+**Why circuits are individual:** Circuits often have 3-5 exercises. Swapping all of them is too destructive — if you hate one movement in the circuit, you shouldn't lose the other four. The AI receives the full circuit context so the replacement fits the flow.
+
+**Why supersets are a unit:** A superset pair is designed to work together (agonist/antagonist, pre-exhaust, etc.). Swapping one leg without the other could break the training logic. Better to regenerate the pair.
+
+---
+
+## API Design
+
+### Endpoint: `POST /generate/section` (New Edge Function)
+
+A new Supabase Edge Function (`supabase/functions/generate-section/index.ts`), separate from the existing `generate-workout` function for separation of concerns. The AI receives full context about what's staying so the replacement fits.
+
+```typescript
+// Request
+{
+  session_context: {
+    intensity: number;
+    anchor: AnchorType;        // or goal if v3 prompt is live
+    location_id: string;
+  };
+  section_type: SectionType;
+  exclude_exercises?: string[];  // don't suggest these (from other sections)
+
+  // Swap-specific fields
+  swap_mode: 'section' | 'single' | 'unit';  // required
+  swap_target: {
+    exercise_name?: string;      // for single swap
+    group_id?: string;           // for unit swap (superset id, circuit id, etc.)
+    structure_type?: string;     // 'superset' | 'emom' | 'amrap' | 'afap' | 'timed'
+  };
+  keep_exercises: GeneratedExercise[];  // exercises staying in the section (provides context)
+}
+```
+
+### Prompt Strategy
+
+The prompt tells the AI exactly what's happening. Three variations based on `swap_mode`:
+
+**Single swap (standard exercise):**
+```
+SWAP MODE: single
+Replace ONLY "{exercise_name}" in this section.
+Exercises staying (do not duplicate these): {keep_exercise_names}
+The replacement should:
+- Fit the same role in the section
+- Use available equipment: {equipment}
+- Match intensity level: {intensity}/10
+- Not duplicate any exercise in the full workout
+Return the full section with ONE exercise replaced.
+```
+
+**Single swap (circuit exercise):**
+```
+SWAP MODE: single (within circuit)
+Replace ONLY "{exercise_name}" in this circuit.
+Other circuit exercises (the replacement must complement these): {other_circuit_exercises}
+Other section exercises (do not duplicate): {other_section_exercises}
+The replacement should:
+- Fit the circuit's flow and intent
+- Use available equipment: {equipment}
+- Maintain similar work/rest timing
+Return the full section with ONE circuit exercise replaced.
+```
+
+**Unit swap (superset, EMOM, AMRAP, afap/timed):**
+```
+SWAP MODE: unit
+Replace the entire {structure_type} group: {group_exercise_names}
+Other exercises in this section (do not duplicate): {other_section_exercises}
+The replacement group should:
+- Serve the same training purpose as the original group
+- Maintain the same structure type ({structure_type})
+- Use available equipment: {equipment}
+- Match intensity level: {intensity}/10
+Return the full section with the group replaced.
+```
+
+### Response Handling
+
+The AI always returns a full section. The frontend:
+1. Identifies which exercise(s) changed
+2. Patches only those into local state
+3. Preserves everything else
+
+### Required Type Change: Unified `group_id`
+
+A `group_id: string` field must be added to every non-standard variant of the `ExerciseStructure` union type:
+
+- `superset` — gets `group_id` (preserves existing `paired_with`)
+- `circuit` — gets `group_id` (preserves existing `circuit_id`)
+- `emom` — gets `group_id`
+- `amrap` — gets `group_id`
+- `afap` — gets `group_id`
+- `timed` — gets `group_id`
+- `standard` — does NOT get `group_id`
+
+Existing fields (`paired_with`, `circuit_id`) are preserved for backward compatibility. The workout generation prompt must assign `group_id` to all exercises within a grouped structure (same ID for exercises in the same group).
+
+---
+
+## UI Specification
+
+### Swap Icon Placement
+
+**Location:** Inside expanded exercise details only (reduces visual noise when scanning collapsed cards).
+
+**For individual exercises (standard + circuit):**
+```
+┌─────────────────────────────────────┐
+│ ARM CIRCLES  BODYWEIGHT         ▼   │  ← collapsed: no swap icon
+└─────────────────────────────────────┘
+
+┌─────────────────────────────────────┐
+│ ARM CIRCLES  BODYWEIGHT         ▲   │  ← expanded
+│ 1×10 each direction                 │
+│ Tempo: controlled                   │
+│ Coaching: Big circles, full ROM     │
+│                                     │
+│                            [ ↻ Swap ]│  ← swap icon/button
+└─────────────────────────────────────┘
+```
+
+**For unit groups (superset, EMOM, AMRAP, afap/timed):**
+```
+┌─────────────────────────────────────┐
+│ SUPERSET                        ▲   │
+│                                     │
+│  DB Bench Press — 3×10              │
+│  DB Bent-Over Row — 3×10           │
+│                                     │
+│                     [ ↻ Swap Pair ] │  ← one icon for the unit
+└─────────────────────────────────────┘
+```
+
+**Icon spec:**
+- Icon: ↻ (swap/refresh)
+- Size: 16–20px icon, 44×44px minimum touch target
+- Default: Muted color (`text-muted` token)
+- Hover/tap: Brightens to primary color
+- Label text adapts: "Swap" for single, "Swap Pair" for superset, "Swap Block" for EMOM/AMRAP/afap/timed
+
+### No More "Randomize Section" Button
+
+The per-exercise/per-group swap icons replace the section-level "Randomize Section" button. Users now have more precise control. If someone wants to replace an entire section, they swap each exercise individually — or regenerate the whole workout.
+
+**Connected structures are fully covered:** If a section is entirely one EMOM block or one superset pair, the unit swap icon is functionally identical to what "Randomize Section" used to do — it replaces everything in the section. The only tradeoff is sections with multiple standalone exercises (e.g., a warm-up with 4 standard exercises), which now require individual swaps rather than one bulk action. This is intentional — granular control is the goal.
+
+---
+
+## Swap Limits & History
+
+### 3-Swap Limit Per Slot
+
+Each exercise slot (or unit group slot) allows up to 3 swaps before locking.
+
+**Tracking:** Maintain a swap history array per slot in local state:
+
+```typescript
+interface SwapSlot {
+  current: GeneratedExercise | GeneratedExercise[];  // current exercise(s)
+  history: (GeneratedExercise | GeneratedExercise[])[];  // up to 3 previous
+  swapCount: number;
+}
+```
+
+**After 3 swaps:** Swap icon becomes disabled. Show an **informational toast** (not error — the user hasn't done anything wrong, we're offering guidance):
+
+```
+Toast (informational style):
+"Nothing feeling right? Try regenerating with different inputs."
+[Regenerate Workout]
+```
+
+- Uses existing toast component with informational variant
+- "Regenerate Workout" action takes the user back to Screen 1 (Generation Input) with current settings pre-filled
+- Toast auto-dismisses after standard duration, but the swap icon stays disabled
+
+### Undo / Swap History
+
+Users can cycle back through their previous 3 exercises for that slot.
+
+**UI pattern:** After the first swap, a small "Previous" link/button appears below the swap icon:
+
+```
+┌─────────────────────────────────────┐
+│ DB LATERAL RAISE  DUMBBELLS     ▲   │
+│ 3×12                                │
+│ ...                                 │
+│                                     │
+│              [ ← Previous ] [ ↻ Swap ]│
+└─────────────────────────────────────┘
+```
+
+- Tapping "Previous" cycles backward through swap history (no API call — it's in memory)
+- Tapping "Swap" generates a new option and pushes current to history
+- History is capped at 3 entries (oldest drops off)
+
+---
+
+## State Management
+
+### Local State Only
+
+All swap state lives in memory. Nothing is persisted to the database until the user taps "Start Workout." This keeps swaps fully reversible and avoids unnecessary writes.
+
+### State Shape
+
+```typescript
+// Per-section swap tracking
+interface SectionSwapState {
+  [exerciseIndex: number]: SwapSlot;  // keyed by position in section
+}
+
+// Top-level swap state alongside generatedWorkout
+interface SwapState {
+  [sectionType: string]: SectionSwapState;
+}
+```
+
+> **Note on index-based keying:** Exercises do not reorder during preview, so keying by position is safe. If future features allow drag-to-reorder, this would need to switch to a stable exercise identifier.
+
+### Single Exercise Swap
+```typescript
+// Replace one exercise within a section
+setGeneratedWorkout(prev => ({
+  ...prev,
+  sections: prev.sections.map(s =>
+    s.section_type === targetSectionType
+      ? {
+          ...s,
+          exercises: s.exercises.map((ex, i) =>
+            i === targetIndex ? newExercise : ex
+          )
+        }
+      : s
+  )
+}));
+```
+
+### Unit Swap
+```typescript
+// Replace all exercises matching the group ID
+setGeneratedWorkout(prev => ({
+  ...prev,
+  sections: prev.sections.map(s =>
+    s.section_type === targetSectionType
+      ? {
+          ...s,
+          exercises: s.exercises.map(ex =>
+            ex.structure?.group_id === targetGroupId ? findReplacement(ex, newExercises) : ex
+          )
+        }
+      : s
+  )
+}));
+```
+
+---
+
+## Loading State
+
+**Placeholder implementation for now.** Use a simple dim + spinner on the affected card(s). This will be revisited as part of a broader loading/feedback design pass.
+
+- Single swap: Affected card dims (opacity 0.5), small spinner where swap icon was
+- Unit swap: All cards in the group dim, spinner on the group
+- Card height must NOT collapse during loading — maintain layout stability
+- Placeholder is intentionally minimal — designed to be replaced
+
+---
+
+## Error Handling
+
+- **API timeout / failure:** Show inline error on the affected card. Don't clear existing content. Let user retry. Error does not consume a swap attempt.
+- **Invalid AI response:** Catch in validation, show error, let user retry.
+- **Debounce:** 2-second minimum between swap calls per slot to prevent rapid-fire API hits.
+
+---
+
+## Acceptance Criteria
+
+### Single Exercise Swap
+- [ ] Swap icon visible inside expanded details on standard-structure exercises
+- [ ] Swap icon visible on individual circuit exercises
+- [ ] Tapping swap calls `POST /generate/section` with `swap_mode: 'single'` and full context
+- [ ] Only the targeted exercise updates — rest of section unchanged
+- [ ] AI receives context about exercises staying in the section/circuit
+- [ ] Loading state visible on individual card during generation
+- [ ] Error state preserves existing exercise
+
+### Unit Swap
+- [ ] Superset pairs show one swap icon for the group
+- [ ] EMOM/AMRAP/afap/timed blocks show one swap icon for the group
+- [ ] Tapping swap replaces the entire unit
+- [ ] AI returns a replacement with the same structure type
+- [ ] All cards in the group update together
+
+### Swap Limits & History
+- [ ] Swap counter increments per slot (not globally)
+- [ ] After 3 swaps, icon disabled + "regenerate workout" nudge shown
+- [ ] Failed swaps do not count toward the limit
+- [ ] "Previous" button appears after first swap
+- [ ] Cycling through history does not make API calls
+- [ ] History capped at 3 entries per slot
+
+### General
+- [ ] No "Randomize Section" button — replaced by per-exercise/per-group swap icons
+- [ ] No database writes until "Start Workout"
+- [ ] Works on mobile (touch targets ≥ 44px)
+- [ ] Uses design tokens for all colors, spacing, typography
+- [ ] Debounced to prevent rapid-fire API calls
+
+---
+
+## Phase B (Backlog — Future Work)
+
+For reference, Phase B adds the multi-select edit mode flow:
+
+- Tap "Edit" on section header → section enters edit mode
+- Each exercise becomes a selectable checkbox (multi-select, uses existing chip pattern from Generation screen)
+- "Swap Selected" CTA appears at bottom of section
+- AI replaces only selected exercises, returns section with swaps in place
+- Possible: mid-workout swap on Screen 3
+- Possible: smarter loading states (shimmer, "Finding alternatives..." messaging)
+
+Phase B needs its own spec and design exploration before implementation.
+
+---
+
+*Draft created: March 4, 2026*  
+*Decisions captured: March 4, 2026 — API Option A, unit swap rules, 3-swap limit with history, placeholder loading*
+*Revised: March 4, 2026 — Fixed structure type names (afap/timed not ladder), added unified group_id to types, new generate-section edge function, index-keying safety note*

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -1,10 +1,20 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, RefreshCw, ChevronLeft, Loader2 } from "lucide-react";
 import { Exercise } from "@/types/workout";
+import { CardLoader } from "@/components/ScanLoader";
 
 interface ExerciseCardProps {
   exercise: Exercise;
   defaultExpanded?: boolean;
+  onExpandChange?: (expanded: boolean) => void;
+  // Swap props (optional — only used on Review screen)
+  onSwap?: () => void;
+  onPrevious?: () => void;
+  isSwapLoading?: boolean;
+  isSwapDisabled?: boolean;
+  hasPrevious?: boolean;
+  swapError?: string | null;
+  showSwapControls?: boolean;
 }
 
 /** Check if a rest value is meaningful (non-zero, non-empty) */
@@ -14,20 +24,34 @@ const hasRest = (rest?: string): boolean => {
   return cleaned !== '0s' && cleaned !== '0' && cleaned !== '';
 };
 
-export const ExerciseCard = ({ exercise, defaultExpanded = false }: ExerciseCardProps) => {
+export const ExerciseCard = ({
+  exercise,
+  defaultExpanded = false,
+  onExpandChange,
+  onSwap,
+  onPrevious,
+  isSwapLoading = false,
+  isSwapDisabled = false,
+  hasPrevious = false,
+  swapError,
+  showSwapControls = false,
+}: ExerciseCardProps) => {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   return (
-    <div>
+    <div style={{ position: 'relative', overflow: 'hidden' }}>
+      {/* Card loader overlay — replaces opacity dim during swap */}
+      {showSwapControls && <CardLoader running={isSwapLoading} />}
+
       {/* Header - always visible */}
       <button
-        onClick={() => setIsExpanded(!isExpanded)}
+        onClick={() => { const next = !isExpanded; setIsExpanded(next); onExpandChange?.(next); }}
         className="w-full flex items-start gap-3 text-left py-2 px-4"
       >
         <div className="flex-1 min-w-0 space-y-1">
           <h4
-            className="text-heading-h6 font-bold leading-tight uppercase"
-            style={{ color: 'var(--text-card-header)' }}
+            className="text-label-md font-bold leading-tight uppercase"
+            style={{ fontFamily: 'var(--font-headings)', color: 'var(--text-card-header)' }}
           >
             {exercise.name}
           </h4>
@@ -98,6 +122,54 @@ export const ExerciseCard = ({ exercise, defaultExpanded = false }: ExerciseCard
                 <p><span style={{ color: 'var(--text-disabled)' }}>Harder:</span> {exercise.progression}</p>
               )}
             </div>
+          )}
+
+          {/* Swap controls — only in expanded state, only for standard/circuit exercises */}
+          {showSwapControls && (
+            <div className="flex items-center gap-2 pt-1">
+              {/* Previous button — only after first swap */}
+              {hasPrevious && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); onPrevious?.(); }}
+                  className="flex items-center gap-1 pr-3 transition-colors"
+                  style={{
+                    color: 'var(--icon-cta)',
+                    minHeight: '44px',
+                    minWidth: '44px',
+                  }}
+                >
+                  <ChevronLeft size={16} />
+                  <span className="text-label-xs uppercase tracking-wider">Previous</span>
+                </button>
+              )}
+
+              {/* Swap button */}
+              <button
+                onClick={(e) => { e.stopPropagation(); onSwap?.(); }}
+                disabled={isSwapDisabled || isSwapLoading}
+                className="flex items-center gap-1 pr-3 transition-colors"
+                style={{
+                  color: isSwapDisabled ? 'var(--text-disabled)' : 'var(--icon-cta)',
+                  minHeight: '44px',
+                  minWidth: '44px',
+                  cursor: isSwapDisabled ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {isSwapLoading ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  <RefreshCw size={16} />
+                )}
+                <span className="text-label-xs uppercase tracking-wider">Swap</span>
+              </button>
+            </div>
+          )}
+
+          {/* Swap error */}
+          {swapError && (
+            <p className="text-paragraph-sm" style={{ color: 'var(--status-error)' }}>
+              {swapError}
+            </p>
           )}
         </div>
       )}

--- a/src/components/LocationAccordion.tsx
+++ b/src/components/LocationAccordion.tsx
@@ -32,7 +32,7 @@ export const LocationAccordion = ({ selected, onSelect, locations }: LocationAcc
           </span>
           <span
             className="text-heading-h5 font-bold"
-            style={{ color: "var(--text-cta)" }}
+            style={{ color: "var(--icon-cta)" }}
           >
             {displayName}
           </span>

--- a/src/components/ScanLoader/BootScreen.tsx
+++ b/src/components/ScanLoader/BootScreen.tsx
@@ -1,0 +1,186 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { ScanLoader } from './ScanLoader';
+
+// ============================================
+// TYPES
+// ============================================
+
+interface BootScreenProps {
+  /** True when auth/data has resolved — boot will finish current sweep then exit */
+  ready: boolean;
+  /** Called after final sweep completes — parent navigates here */
+  onComplete: () => void;
+}
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+const BOOT_MESSAGES = [
+  'AUTHENTICATING USER',
+  'LOADING TRAINING HISTORY',
+  'CALIBRATING INTENSITY',
+  'GENERATING WORKOUT',
+  'SYSTEM READY',
+];
+
+const TYPEWRITER_MS = 42;
+
+// ============================================
+// COMPONENT
+// ============================================
+
+export const BootScreen = ({ ready, onComplete }: BootScreenProps) => {
+  const [sweepCount, setSweepCount] = useState(0);
+  const [displayText, setDisplayText] = useState('');
+  const [progress, setProgress] = useState(0);
+  const [isRunning, setIsRunning] = useState(true);
+  const typewriterRef = useRef<ReturnType<typeof setInterval>>(null);
+  const hasCompletedRef = useRef(false);
+  const readyRef = useRef(ready);
+
+  // Keep ref in sync so the sweep callback sees latest value
+  readyRef.current = ready;
+
+  // Typewriter effect for status messages
+  const typeMessage = useCallback((text: string) => {
+    if (typewriterRef.current) clearInterval(typewriterRef.current);
+    setDisplayText('');
+    let i = 0;
+    typewriterRef.current = setInterval(() => {
+      if (i < text.length) {
+        i++;
+        setDisplayText(text.slice(0, i));
+      } else {
+        if (typewriterRef.current) clearInterval(typewriterRef.current);
+      }
+    }, TYPEWRITER_MS);
+  }, []);
+
+  // Type the first message on mount
+  useEffect(() => {
+    typeMessage(BOOT_MESSAGES[0]);
+    return () => {
+      if (typewriterRef.current) clearInterval(typewriterRef.current);
+    };
+  }, [typeMessage]);
+
+  // Handle sweep completion — called when ScanLoader finishes one down sweep
+  const handleSweepComplete = useCallback(() => {
+    if (hasCompletedRef.current) return;
+
+    const nextSweep = sweepCount + 1;
+
+    // If ready OR all messages played, exit
+    if (readyRef.current || nextSweep >= BOOT_MESSAGES.length) {
+      hasCompletedRef.current = true;
+      setIsRunning(false);
+      setProgress(100);
+      onComplete();
+      return;
+    }
+
+    // Advance to next sweep — key change will remount ScanLoader for fresh sweep
+    setSweepCount(nextSweep);
+    setProgress(Math.round((nextSweep / BOOT_MESSAGES.length) * 100));
+    typeMessage(BOOT_MESSAGES[nextSweep]);
+  }, [sweepCount, onComplete, typeMessage]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center backdrop-blur-sm"
+      style={{ backgroundColor: 'rgba(23, 23, 23, 0.15)' }}
+    >
+      {/* Canvas — fills entire screen, key forces remount per sweep */}
+      <div className="absolute inset-0">
+        <ScanLoader
+          key={sweepCount}
+          direction="down-once"
+          running={isRunning}
+          onSweepComplete={handleSweepComplete}
+        />
+      </div>
+
+      {/* Logo */}
+      <div className="relative z-10 select-none">
+        <h1
+          className="font-bold uppercase relative"
+          style={{
+            fontFamily: "'Oxanium', monospace",
+            fontSize: 'clamp(52px, 12vw, 80px)',
+            letterSpacing: '0.18em',
+            color: 'var(--color-neutral-50)',
+            lineHeight: 1,
+          }}
+        >
+          CLEAR
+          {/* Rule across logo at 57% */}
+          <span
+            className="absolute pointer-events-none"
+            style={{
+              left: '-12%',
+              right: '-12%',
+              height: '2px',
+              top: '57%',
+              background: 'var(--primary)',
+              boxShadow: '0 0 8px var(--primary), 0 0 20px color-mix(in srgb, var(--primary) 40%, transparent), 0 0 40px color-mix(in srgb, var(--primary) 15%, transparent)',
+            }}
+          />
+        </h1>
+      </div>
+
+      {/* Status message */}
+      <div
+        className="relative z-10 mt-7 min-h-[18px]"
+        style={{
+          fontFamily: "'Oxanium', monospace",
+          fontWeight: 500,
+          fontSize: '11px',
+          letterSpacing: '0.32em',
+          color: 'var(--primary)',
+          textTransform: 'uppercase',
+        }}
+      >
+        {displayText}
+      </div>
+
+      {/* Progress bar — bottom center */}
+      <div
+        className="absolute z-10"
+        style={{
+          bottom: '52px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: 'min(260px, 65vw)',
+        }}
+      >
+        <div
+          className="text-right mb-1.5"
+          style={{
+            fontSize: '9px',
+            letterSpacing: '0.3em',
+            color: 'color-mix(in srgb, var(--primary) 40%, transparent)',
+          }}
+        >
+          {progress}%
+        </div>
+        <div
+          style={{
+            height: '1px',
+            background: 'color-mix(in srgb, var(--primary) 10%, transparent)',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${progress}%`,
+              background: 'var(--primary)',
+              boxShadow: '0 0 6px color-mix(in srgb, var(--primary) 70%, transparent)',
+              transition: 'width 0.08s linear',
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ScanLoader/CardLoader.tsx
+++ b/src/components/ScanLoader/CardLoader.tsx
@@ -1,0 +1,130 @@
+import { useRef, useEffect } from 'react';
+import {
+  type Cell,
+  CW, CH,
+  makeGrid,
+  easeInOutQuad,
+  readThemeRGB,
+  drawNoise,
+  drawScanLine,
+  drawCRTLines,
+} from './canvas-utils';
+
+// ============================================
+// TYPES
+// ============================================
+
+interface CardLoaderProps {
+  /** true starts the bounce loop, false triggers fade-out */
+  running: boolean;
+}
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+const SWEEP_MS = 2000;
+const FADE_MS = 260;
+
+// ============================================
+// COMPONENT
+// ============================================
+
+/**
+ * Overlay loader for exercise cards during swap.
+ * Bounce loop (fill up / clear down) while running, fades out when stopped.
+ * Parent needs position:relative overflow:hidden.
+ */
+export const CardLoader = ({ running }: CardLoaderProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+  const runningRef = useRef(running);
+  runningRef.current = running;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const parent = canvas.parentElement;
+    if (!parent) return;
+
+    if (!running) {
+      // Fade out
+      const start = performance.now();
+      const fadeOut = (ts: number) => {
+        const p = Math.min((ts - start) / FADE_MS, 1);
+        canvas.style.opacity = (1 - p).toFixed(3);
+        if (p < 1) {
+          rafRef.current = requestAnimationFrame(fadeOut);
+        } else {
+          canvas.style.opacity = '0';
+          const ctx = canvas.getContext('2d');
+          if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+        }
+      };
+      rafRef.current = requestAnimationFrame(fadeOut);
+      return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
+    }
+
+    // Setup canvas
+    const rect = parent.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+    canvas.style.opacity = '1';
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.scale(dpr, dpr);
+
+    const w = rect.width;
+    const h = rect.height;
+    const cols = Math.ceil(w / CW) + 2;
+    const rows = Math.ceil(h / CH) + 2;
+    const grid: Cell[][] = makeGrid(cols, rows);
+    const rgb = readThemeRGB();
+
+    let filling = true;
+    let t0: number | null = null;
+
+    const frame = (ts: number) => {
+      if (t0 === null) t0 = ts;
+
+      const p = Math.min((ts - t0) / SWEEP_MS, 1);
+      const e = easeInOutQuad(p);
+
+      // Same bounce logic as ScanLoader
+      const scanY = filling ? h * (1 - e) : h * e;
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      drawCRTLines(ctx, w, h);
+      drawNoise(ctx, grid, scanY, cols, rows, rgb, 1);
+      drawScanLine(ctx, scanY, w, h, rgb);
+
+      if (p >= 1) {
+        filling = !filling;
+        t0 = null;
+      }
+
+      rafRef.current = requestAnimationFrame(frame);
+    };
+
+    rafRef.current = requestAnimationFrame(frame);
+
+    return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
+  }, [running]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 2,
+        pointerEvents: 'none',
+        opacity: 0,
+      }}
+    />
+  );
+};

--- a/src/components/ScanLoader/FullscreenLoader.tsx
+++ b/src/components/ScanLoader/FullscreenLoader.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, useRef } from 'react';
+import { ScanLoader } from './ScanLoader';
+import { CTAButton } from '@/components/CTAButton';
+
+// ============================================
+// TYPES
+// ============================================
+
+interface FullscreenLoaderProps {
+  /** Contextual message, e.g. 'GENERATING WORKOUT' */
+  message: string;
+  /** Controls show/hide */
+  visible: boolean;
+  /** Optional cancel callback — shows an abort button when provided */
+  onCancel?: () => void;
+}
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+const TYPEWRITER_MS = 42;
+
+// ============================================
+// COMPONENT
+// ============================================
+
+export const FullscreenLoader = ({ message, visible, onCancel }: FullscreenLoaderProps) => {
+  const [displayText, setDisplayText] = useState('');
+  const typewriterRef = useRef<ReturnType<typeof setInterval>>(null);
+
+  // Typewriter on mount / message change when visible
+  useEffect(() => {
+    if (!visible) return;
+
+    if (typewriterRef.current) clearInterval(typewriterRef.current);
+    setDisplayText('');
+    let i = 0;
+    typewriterRef.current = setInterval(() => {
+      if (i < message.length) {
+        i++;
+        setDisplayText(message.slice(0, i));
+      } else {
+        if (typewriterRef.current) clearInterval(typewriterRef.current);
+      }
+    }, TYPEWRITER_MS);
+
+    return () => {
+      if (typewriterRef.current) clearInterval(typewriterRef.current);
+    };
+  }, [visible, message]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center backdrop-blur-sm"
+      style={{ backgroundColor: 'rgba(23, 23, 23, 0.15)' }}
+    >
+      {/* Canvas — fills entire screen */}
+      <div className="absolute inset-0">
+        <ScanLoader direction="bounce" running={visible} />
+      </div>
+
+      {/* Message — centered */}
+      <div
+        className="relative z-10 min-h-[18px]"
+        style={{
+          fontFamily: "'Oxanium', monospace",
+          fontWeight: 600,
+          fontSize: '11px',
+          letterSpacing: '0.32em',
+          color: 'var(--text-card-header)',
+          textTransform: 'uppercase',
+        }}
+      >
+        {displayText}
+      </div>
+
+      {/* Cancel button — same position/size as the Generate CTA underneath */}
+      {onCancel && (
+        <div className="absolute bottom-0 left-0 right-0 p-4 z-10">
+          <div className="max-w-md mx-auto">
+            <CTAButton variant="secondary" size="lg" fullWidth onClick={onCancel}>
+              Cancel
+            </CTAButton>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ScanLoader/ScanLoader.tsx
+++ b/src/components/ScanLoader/ScanLoader.tsx
@@ -1,0 +1,172 @@
+import { useRef, useEffect, useCallback } from 'react';
+import {
+  type Cell,
+  CW, CH,
+  makeGrid,
+  easeInOutQuad,
+  readThemeRGB,
+  drawNoise,
+  drawScanLine,
+  drawCRTLines,
+} from './canvas-utils';
+
+// ============================================
+// TYPES
+// ============================================
+
+export interface ScanLoaderProps {
+  /** 'down-once' for boot/card, 'bounce' for fullscreen loop */
+  direction?: 'down-once' | 'bounce';
+  /** Controls animation start/stop */
+  running: boolean;
+  /** Fires when a sweep completes (once for down-once, each direction flip for bounce) */
+  onSweepComplete?: () => void;
+}
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+const SWEEP_MS = 2000;
+
+// ============================================
+// COMPONENT
+// ============================================
+
+export const ScanLoader = ({
+  direction = 'down-once',
+  running,
+  onSweepComplete,
+}: ScanLoaderProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+  const stateRef = useRef({
+    grid: null as Cell[][] | null,
+    cols: 0,
+    rows: 0,
+    filling: true, // true = fill sweep (up), false = clear sweep (down)
+    t0: null as number | null,
+    rgb: [248, 120, 35] as [number, number, number],
+  });
+
+  const resize = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const parent = canvas.parentElement;
+    if (!parent) return;
+
+    const rect = parent.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+
+    const ctx = canvas.getContext('2d');
+    if (ctx) ctx.scale(dpr, dpr);
+
+    const cols = Math.ceil(rect.width / CW) + 2;
+    const rows = Math.ceil(rect.height / CH) + 2;
+    stateRef.current.cols = cols;
+    stateRef.current.rows = rows;
+    stateRef.current.grid = makeGrid(cols, rows);
+  }, []);
+
+  // Animation loop
+  useEffect(() => {
+    if (!running) {
+      // Clear canvas when stopped
+      const canvas = canvasRef.current;
+      if (canvas) {
+        const ctx = canvas.getContext('2d');
+        if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+      }
+      return;
+    }
+
+    stateRef.current.rgb = readThemeRGB();
+    resize();
+    stateRef.current.t0 = null;
+    stateRef.current.filling = true; // start with fill sweep (up)
+
+    const frame = (ts: number) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const s = stateRef.current;
+      if (!s.grid) return;
+
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+
+      if (s.t0 === null) s.t0 = ts;
+
+      const p = Math.min((ts - s.t0) / SWEEP_MS, 1);
+      const e = easeInOutQuad(p);
+
+      let scanY: number;
+      if (direction === 'down-once') {
+        scanY = e * h;
+      } else {
+        // Bounce: fill sweep goes up (h→0), clear sweep goes down (0→h)
+        // Noise is always drawn below scanY (dir=1)
+        // Fill: scanY shrinks → noise zone grows (fills from bottom)
+        // Clear: scanY grows → noise zone shrinks (clears from top)
+        scanY = s.filling ? h * (1 - e) : h * e;
+      }
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      drawCRTLines(ctx, w, h);
+      // Always dir=1: noise draws below scanY. Scan direction handles fill vs clear.
+      drawNoise(ctx, s.grid, scanY, s.cols, s.rows, s.rgb, 1);
+      drawScanLine(ctx, scanY, w, h, s.rgb);
+
+      if (p >= 1) {
+        if (direction === 'down-once') {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          onSweepComplete?.();
+          return;
+        } else {
+          // Bounce: alternate fill/clear — keep the same grid (no re-seed)
+          s.filling = !s.filling;
+          s.t0 = null;
+          onSweepComplete?.();
+        }
+      }
+
+      rafRef.current = requestAnimationFrame(frame);
+    };
+
+    rafRef.current = requestAnimationFrame(frame);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [running, direction, onSweepComplete, resize]);
+
+  // ResizeObserver
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas?.parentElement) return;
+
+    const observer = new ResizeObserver(() => {
+      if (running) resize();
+    });
+    observer.observe(canvas.parentElement);
+    return () => observer.disconnect();
+  }, [running, resize]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+      }}
+    />
+  );
+};

--- a/src/components/ScanLoader/canvas-utils.ts
+++ b/src/components/ScanLoader/canvas-utils.ts
@@ -1,0 +1,184 @@
+// ============================================
+// Shared canvas utilities for ScanLoader variants
+// ============================================
+
+export const CW = 4;  // pixel cell width — small for dense static
+export const CH = 4;  // pixel cell height
+
+// ============================================
+// GRID
+// ============================================
+
+export interface Cell {
+  op: number; // base opacity 0.03–0.18
+  fr: number; // flicker rate — lower = more flicker
+}
+
+export function makeGrid(cols: number, rows: number): Cell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({
+      op: 0.03 + Math.random() * 0.15,
+      fr: 0.82 + Math.random() * 0.16, // faster flicker than text variant
+    }))
+  );
+}
+
+// ============================================
+// EASING
+// ============================================
+
+export function easeInOutQuad(p: number): number {
+  return p < 0.5 ? 2 * p * p : 1 - Math.pow(-2 * p + 2, 2) / 2;
+}
+
+// ============================================
+// COLOR
+// ============================================
+
+/**
+ * Parse a CSS color (hex or rgb) to [r, g, b] tuple.
+ * Falls back to orange-500 if parsing fails.
+ */
+export function parseColor(color: string): [number, number, number] {
+  const trimmed = color.trim();
+
+  if (trimmed.startsWith('#')) {
+    const hex = trimmed.slice(1);
+    if (hex.length === 3) {
+      return [
+        parseInt(hex[0] + hex[0], 16),
+        parseInt(hex[1] + hex[1], 16),
+        parseInt(hex[2] + hex[2], 16),
+      ];
+    }
+    if (hex.length >= 6) {
+      return [
+        parseInt(hex.slice(0, 2), 16),
+        parseInt(hex.slice(2, 4), 16),
+        parseInt(hex.slice(4, 6), 16),
+      ];
+    }
+  }
+
+  const match = trimmed.match(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (match) {
+    return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])];
+  }
+
+  return [248, 120, 35];
+}
+
+/** Read the --primary-300 CSS custom property and parse to RGB */
+export function readThemeRGB(): [number, number, number] {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue('--primary-300');
+  return raw ? parseColor(raw) : [251, 174, 123];
+}
+
+// ============================================
+// DRAWING
+// ============================================
+
+/** Draw scan-relative static noise — clears on trailing side of scanY */
+export function drawNoise(
+  ctx: CanvasRenderingContext2D,
+  grid: Cell[][],
+  scanY: number,
+  cols: number,
+  rows: number,
+  rgb: [number, number, number],
+  dir: 1 | -1 = 1,
+  globalAlpha = 1
+) {
+  const [r, g, b] = rgb;
+  for (let row = 0; row < rows; row++) {
+    const cy = row * CH;
+    const dist = dir === 1 ? cy - scanY : scanY - cy;
+    if (dist < -CH) continue;
+    for (let col = 0; col < cols; col++) {
+      const cell = grid[row][col];
+      // Flicker: randomly reassign opacity
+      if (Math.random() > cell.fr) {
+        cell.op = 0.03 + Math.random() * 0.15;
+      }
+      const fadeIn = Math.min(dist / 32, 1);
+      const prox = Math.max(0, 1 - Math.abs(dist) / 60) * 0.08;
+      const a = (cell.op + prox) * Math.max(0, fadeIn) * globalAlpha;
+      if (a < 0.004) continue;
+      ctx.fillStyle = `rgba(${r},${g},${b},${a.toFixed(3)})`;
+      ctx.fillRect(col * CW, cy, CW - 1, CH - 1);
+    }
+  }
+}
+
+/** Draw uniform static noise — no scan-relative clearing */
+export function drawStaticNoise(
+  ctx: CanvasRenderingContext2D,
+  grid: Cell[][],
+  cols: number,
+  rows: number,
+  rgb: [number, number, number],
+  globalAlpha = 1
+) {
+  const [r, g, b] = rgb;
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const cell = grid[row][col];
+      if (Math.random() > cell.fr) {
+        cell.op = 0.03 + Math.random() * 0.15;
+      }
+      const a = cell.op * globalAlpha;
+      if (a < 0.004) continue;
+      ctx.fillStyle = `rgba(${r},${g},${b},${a.toFixed(3)})`;
+      ctx.fillRect(col * CW, row * CH, CW - 1, CH - 1);
+    }
+  }
+}
+
+/** Draw the glowing scan line */
+export function drawScanLine(
+  ctx: CanvasRenderingContext2D,
+  scanY: number,
+  width: number,
+  height: number,
+  rgb: [number, number, number]
+) {
+  if (scanY < -4 || scanY > height + 4) return;
+  const [r, g, b] = rgb;
+
+  const grad = ctx.createLinearGradient(0, scanY - 12, 0, scanY + 12);
+  grad.addColorStop(0, `rgba(${r},${g},${b},0)`);
+  grad.addColorStop(0.5, `rgba(${r},${g},${b},0.15)`);
+  grad.addColorStop(1, `rgba(${r},${g},${b},0)`);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, scanY - 12, width, 24);
+
+  ctx.save();
+  ctx.shadowColor = `rgba(${r},${g},${b},0.7)`;
+  ctx.shadowBlur = 14;
+  ctx.beginPath();
+  ctx.moveTo(0, scanY);
+  ctx.lineTo(width, scanY);
+  ctx.strokeStyle = `rgb(${r},${g},${b})`;
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.shadowBlur = 4;
+  ctx.beginPath();
+  ctx.moveTo(0, scanY);
+  ctx.lineTo(width, scanY);
+  const hr = Math.min(255, r + (255 - r) * 0.5);
+  const hg = Math.min(255, g + (255 - g) * 0.5);
+  const hb = Math.min(255, b + (255 - b) * 0.5);
+  ctx.strokeStyle = `rgba(${hr | 0},${hg | 0},${hb | 0},0.7)`;
+  ctx.lineWidth = 0.7;
+  ctx.stroke();
+  ctx.restore();
+}
+
+/** Subtle CRT horizontal scan line overlay */
+export function drawCRTLines(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  ctx.fillStyle = 'rgba(0,0,0,0.04)';
+  for (let y = 0; y < height; y += 3) {
+    ctx.fillRect(0, y, width, 1);
+  }
+}

--- a/src/components/ScanLoader/index.ts
+++ b/src/components/ScanLoader/index.ts
@@ -1,0 +1,4 @@
+export { ScanLoader } from './ScanLoader';
+export { BootScreen } from './BootScreen';
+export { FullscreenLoader } from './FullscreenLoader';
+export { CardLoader } from './CardLoader';

--- a/src/components/WorkoutSectionCard.tsx
+++ b/src/components/WorkoutSectionCard.tsx
@@ -1,14 +1,121 @@
-import { RefreshCw } from "lucide-react";
-import { WorkoutSection } from "@/types/workout";
+import { useState, useCallback } from "react";
+import { RefreshCw, ChevronLeft, Loader2 } from "lucide-react";
+import { WorkoutSection, Exercise } from "@/types/workout";
 import { ExerciseCard } from "./ExerciseCard";
+import { CardLoader } from "./ScanLoader";
 import { Card } from "./Card";
+
+interface SwapControlsForExercise {
+  onSwap: () => void;
+  onPrevious: () => void;
+  isSwapLoading: boolean;
+  isSwapDisabled: boolean;
+  hasPrevious: boolean;
+  swapError: string | null;
+  showSwapControls: boolean;
+}
+
+interface GroupSwapControls {
+  onSwap: () => void;
+  onPrevious: () => void;
+  isSwapLoading: boolean;
+  isSwapDisabled: boolean;
+  hasPrevious: boolean;
+  label: string; // "Swap Pair" | "Swap Block"
+}
 
 interface WorkoutSectionCardProps {
   section: WorkoutSection;
-  onRandomize?: () => void;
+  /** Per-exercise swap controls, keyed by exercise index */
+  exerciseSwapControls?: Record<number, SwapControlsForExercise>;
+  /** Per-group swap controls, keyed by group_id */
+  groupSwapControls?: Record<string, GroupSwapControls>;
 }
 
-export const WorkoutSectionCard = ({ section, onRandomize }: WorkoutSectionCardProps) => {
+/** Group exercises by group_id for unit swap rendering */
+interface ExerciseGroup {
+  type: 'standalone' | 'group';
+  exercises: { exercise: Exercise; originalIndex: number }[];
+  groupId?: string;
+  structureType?: string;
+}
+
+function groupSectionExercises(exercises: Exercise[]): ExerciseGroup[] {
+  const groups: ExerciseGroup[] = [];
+  const processedIndices = new Set<number>();
+
+  for (let i = 0; i < exercises.length; i++) {
+    if (processedIndices.has(i)) continue;
+
+    const exercise = exercises[i];
+    const structure = exercise.structure;
+
+    // Check if this exercise belongs to a group (non-standard, non-circuit with group_id)
+    const groupId = structure && 'group_id' in structure ? structure.group_id : undefined;
+    const isGroupedType = structure && structure.type !== 'standard' && structure.type !== 'circuit';
+
+    if (groupId && isGroupedType) {
+      // Find all exercises with this group_id
+      const groupMembers: { exercise: Exercise; originalIndex: number }[] = [];
+      for (let j = i; j < exercises.length; j++) {
+        const ex = exercises[j];
+        const exGroupId = ex.structure && 'group_id' in ex.structure ? ex.structure.group_id : undefined;
+        if (exGroupId === groupId) {
+          groupMembers.push({ exercise: ex, originalIndex: j });
+          processedIndices.add(j);
+        }
+      }
+
+      groups.push({
+        type: 'group',
+        exercises: groupMembers,
+        groupId,
+        structureType: structure.type,
+      });
+    } else {
+      // Standalone exercise (standard or circuit)
+      groups.push({
+        type: 'standalone',
+        exercises: [{ exercise, originalIndex: i }],
+      });
+      processedIndices.add(i);
+    }
+  }
+
+  return groups;
+}
+
+function getGroupLabel(structureType?: string): string {
+  if (structureType === 'superset') return 'Superset';
+  if (structureType === 'emom') return 'EMOM';
+  if (structureType === 'amrap') return 'AMRAP';
+  if (structureType === 'for_time') return 'For Time';
+  if (structureType === 'timed') return 'Timed';
+  return structureType || 'Block';
+}
+
+function getSwapLabel(structureType?: string): string {
+  if (structureType === 'superset') return 'Swap Pair';
+  return 'Swap Block';
+}
+
+export const WorkoutSectionCard = ({
+  section,
+  exerciseSwapControls,
+  groupSwapControls,
+}: WorkoutSectionCardProps) => {
+  const groups = groupSectionExercises(section.exercises);
+
+  // Track which exercises are expanded (by originalIndex) for showing group swap controls
+  const [expandedExercises, setExpandedExercises] = useState<Set<number>>(new Set());
+  const handleExpandChange = useCallback((index: number, expanded: boolean) => {
+    setExpandedExercises(prev => {
+      const next = new Set(prev);
+      if (expanded) next.add(index); else next.delete(index);
+      return next;
+    });
+  }, []);
+
   return (
     <Card padding="none" className="overflow-hidden">
       {/* Section label */}
@@ -21,37 +128,113 @@ export const WorkoutSectionCard = ({ section, onRandomize }: WorkoutSectionCardP
         </span>
       </div>
 
-      {/* Exercises - each individually expandable */}
+      {/* Exercises — grouped by structure */}
       <div className="pb-3">
-        {section.exercises.map((exercise, i) => (
-          <div key={exercise.id}>
-            {i > 0 && (
-              <div className="mx-4" style={{ borderTop: '2px solid var(--border-spacer)' }} />
-            )}
-            <ExerciseCard exercise={exercise} />
-          </div>
-        ))}
-      </div>
+        {groups.map((group, groupIdx) => {
+          if (group.type === 'standalone') {
+            // Single exercise — standard or circuit with individual swap
+            const { exercise, originalIndex } = group.exercises[0];
+            const swapProps = exerciseSwapControls?.[originalIndex];
 
-      {/* Randomize button */}
-      {onRandomize && (
-        <div className="px-4 pb-3">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onRandomize();
-            }}
-            className="w-full flex items-center justify-center gap-2 py-3 border transition-colors"
-            style={{
-              borderColor: 'var(--border-card)',
-              color: 'var(--icon-cta)',
-            }}
-          >
-            <RefreshCw size={16} />
-            <span className="text-paragraph-sm font-medium">Randomize Section</span>
-          </button>
-        </div>
-      )}
+            return (
+              <div key={`exercise-${originalIndex}`}>
+                {groupIdx > 0 && (
+                  <div className="mx-4" style={{ borderTop: '2px solid var(--border-spacer)' }} />
+                )}
+                <ExerciseCard
+                  exercise={exercise}
+                  onSwap={swapProps?.onSwap}
+                  onPrevious={swapProps?.onPrevious}
+                  isSwapLoading={swapProps?.isSwapLoading}
+                  isSwapDisabled={swapProps?.isSwapDisabled}
+                  hasPrevious={swapProps?.hasPrevious}
+                  swapError={swapProps?.swapError}
+                  showSwapControls={swapProps?.showSwapControls}
+                />
+              </div>
+            );
+          } else {
+            // Grouped exercises (superset, emom, amrap, for_time) — unit swap
+            const groupControls = group.groupId ? groupSwapControls?.[group.groupId] : undefined;
+            const isLoading = groupControls?.isSwapLoading ?? false;
+
+            return (
+              <div
+                key={`group-${group.groupId || groupIdx}`}
+                style={{ position: 'relative', overflow: 'hidden' }}
+              >
+                {/* Card loader overlay for unit swap */}
+                {groupControls && <CardLoader running={isLoading} />}
+                {groupIdx > 0 && (
+                  <div className="mx-4" style={{ borderTop: '2px solid var(--border-spacer)' }} />
+                )}
+
+                {/* Group label */}
+                <div className="px-4 pt-2 pb-1">
+                  <span
+                    className="text-label-xs font-bold uppercase tracking-widest"
+                    style={{ color: 'var(--text-card-label)' }}
+                  >
+                    {getGroupLabel(group.structureType)}
+                  </span>
+                </div>
+
+                {/* Group exercises — no individual swap controls */}
+                {group.exercises.map(({ exercise, originalIndex }, exIdx) => (
+                  <div key={`exercise-${originalIndex}`}>
+                    {exIdx > 0 && (
+                      <div className="mx-4" style={{ borderTop: '1px solid var(--border-spacer)' }} />
+                    )}
+                    <ExerciseCard
+                      exercise={exercise}
+                      onExpandChange={(expanded) => handleExpandChange(originalIndex, expanded)}
+                    />
+                  </div>
+                ))}
+
+                {/* Unit swap controls — only when any group member is expanded */}
+                {groupControls && group.exercises.some(({ originalIndex }) => expandedExercises.has(originalIndex)) && (
+                  <div className="flex items-center gap-2 px-4 pb-2">
+                    {groupControls.hasPrevious && (
+                      <button
+                        onClick={groupControls.onPrevious}
+                        className="flex items-center gap-1 pr-3 transition-colors"
+                        style={{
+                          color: 'var(--icon-cta)',
+                          minHeight: '44px',
+                          minWidth: '44px',
+                        }}
+                      >
+                        <ChevronLeft size={16} />
+                        <span className="text-label-xs uppercase tracking-wider">Previous</span>
+                      </button>
+                    )}
+
+                    <button
+                      onClick={groupControls.onSwap}
+                      disabled={groupControls.isSwapDisabled || isLoading}
+                      className="flex items-center gap-1 pr-3 transition-colors"
+                      style={{
+                        color: groupControls.isSwapDisabled ? 'var(--text-disabled)' : 'var(--icon-cta)',
+                        minHeight: '44px',
+                        minWidth: '44px',
+                        cursor: groupControls.isSwapDisabled ? 'not-allowed' : 'pointer',
+                      }}
+                    >
+                      {isLoading ? (
+                        <Loader2 size={16} className="animate-spin" />
+                      ) : (
+                        <RefreshCw size={16} />
+                      )}
+                      <span className="text-label-xs uppercase tracking-wider">{groupControls.label}</span>
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          }
+        })}
+      </div>
     </Card>
   );
 };

--- a/src/contexts/WorkoutFlowContext.tsx
+++ b/src/contexts/WorkoutFlowContext.tsx
@@ -13,6 +13,7 @@ import {
 interface WorkoutFlowContextValue {
   workoutParams: WorkoutParams | null;
   generatedWorkout: GeneratedWorkout | null;
+  setGeneratedWorkout: React.Dispatch<React.SetStateAction<GeneratedWorkout | null>>;
   workoutNotes: WorkoutNotes | null;
   totalTime: number;
   isGenerating: boolean;
@@ -24,6 +25,7 @@ interface WorkoutFlowContextValue {
   handleFinishWorkout: (notes: WorkoutNotes, onSuccess?: () => void) => void;
   handleFinishSession: (mood: number | null, sessionNotes: string, onSuccess?: () => void) => Promise<void>;
   handleResumeIncomplete: (incompleteSessionId: string, onSuccess?: () => void) => Promise<boolean>;
+  cancelGeneration: () => void;
 }
 
 const WorkoutFlowContext = createContext<WorkoutFlowContextValue | null>(null);

--- a/src/hooks/useExerciseSwap.ts
+++ b/src/hooks/useExerciseSwap.ts
@@ -1,0 +1,502 @@
+import { useState, useCallback, useRef } from 'react';
+import type { GeneratedWorkout, Exercise, WorkoutSection } from '@/types/workout';
+import type { GeneratedExercise, GeneratedSection, SectionType } from '@/types/generation';
+import { generateSection, isGenerationError } from '@/lib/workout-api';
+import { SECTION_TO_DB } from '@/lib/section-mapping';
+
+// ============================================
+// TYPES
+// ============================================
+
+export interface SwapSlot {
+  current: Exercise | Exercise[];
+  history: (Exercise | Exercise[])[];
+  swapCount: number;
+}
+
+interface SectionSwapState {
+  [key: string]: SwapSlot; // keyed by exerciseIndex (single) or group_id (unit)
+}
+
+interface SwapState {
+  [sectionId: string]: SectionSwapState;
+}
+
+interface SwapLoading {
+  sectionId: string;
+  key: string; // exerciseIndex or group_id
+}
+
+export interface UseExerciseSwapReturn {
+  swapState: SwapState;
+  swapLoading: SwapLoading | null;
+  swapError: { sectionId: string; key: string; message: string } | null;
+  performSwap: (
+    sectionId: string,
+    exerciseIndex: number,
+    sessionContext: SwapSessionContext
+  ) => Promise<void>;
+  performUnitSwap: (
+    sectionId: string,
+    groupId: string,
+    structureType: string,
+    sessionContext: SwapSessionContext
+  ) => Promise<void>;
+  revertToPrevious: (sectionId: string, key: string) => void;
+  getSwapSlot: (sectionId: string, key: string) => SwapSlot | undefined;
+  isSwapDisabled: (sectionId: string, key: string) => boolean;
+}
+
+export interface SwapSessionContext {
+  intensity: number;
+  anchor: string;
+  goal?: string;
+  locationId?: string;
+  equipment?: string[];
+  excludeExercises?: string[];
+}
+
+const MAX_SWAPS = 3;
+const DEBOUNCE_MS = 2000;
+
+// ============================================
+// HOOK
+// ============================================
+
+export function useExerciseSwap(
+  generatedWorkout: GeneratedWorkout | null,
+  setGeneratedWorkout: React.Dispatch<React.SetStateAction<GeneratedWorkout | null>>
+): UseExerciseSwapReturn {
+  const [swapState, setSwapState] = useState<SwapState>({});
+  const [swapLoading, setSwapLoading] = useState<SwapLoading | null>(null);
+  const [swapError, setSwapError] = useState<{ sectionId: string; key: string; message: string } | null>(null);
+  const lastSwapTime = useRef<Record<string, number>>({});
+
+  const getSwapSlot = useCallback(
+    (sectionId: string, key: string): SwapSlot | undefined => {
+      return swapState[sectionId]?.[key];
+    },
+    [swapState]
+  );
+
+  const isSwapDisabled = useCallback(
+    (sectionId: string, key: string): boolean => {
+      const slot = swapState[sectionId]?.[key];
+      return (slot?.swapCount ?? 0) >= MAX_SWAPS;
+    },
+    [swapState]
+  );
+
+  /** Convert a frontend WorkoutSection to a GeneratedSection for the API */
+  const toAPISection = useCallback(
+    (section: WorkoutSection): GeneratedSection => {
+      return {
+        section_type: (SECTION_TO_DB[section.type] || section.type) as SectionType,
+        section_title: section.name,
+        section_notes: null,
+        estimated_duration_mins: 0,
+        exercises: section.exercises.map(toAPIExercise),
+      };
+    },
+    []
+  );
+
+  /** Convert a frontend Exercise to a GeneratedExercise for the API */
+  const toAPIExercise = (exercise: Exercise): GeneratedExercise => {
+    // Map frontend for_time back to API afap
+    const structure = exercise.structure || { type: 'standard' as const };
+    let apiStructure: GeneratedExercise['structure'];
+
+    if (structure.type === 'for_time') {
+      apiStructure = {
+        type: 'afap',
+        time_cap_mins: structure.time_cap_mins,
+        pattern: '',
+        group_id: structure.group_id,
+      };
+    } else if (structure.type === 'circuit') {
+      apiStructure = {
+        type: 'circuit',
+        circuit_id: structure.circuit_id,
+        group_id: structure.group_id,
+      };
+    } else {
+      apiStructure = structure as GeneratedExercise['structure'];
+    }
+
+    return {
+      exercise_id: exercise.id,
+      name: exercise.name,
+      equipment: exercise.equipment || 'bodyweight',
+      sets: exercise.sets,
+      reps: exercise.reps,
+      effort_percent: exercise.effort ? parseInt(exercise.effort) || null : null,
+      tempo: exercise.tempo || null,
+      rest_seconds: exercise.rest ? parseInt(exercise.rest) || null : null,
+      coaching_cues: exercise.coachingCues || [],
+      regression: exercise.regression || null,
+      structure: apiStructure,
+    };
+  };
+
+  const performSwap = useCallback(
+    async (
+      sectionId: string,
+      exerciseIndex: number,
+      sessionContext: SwapSessionContext
+    ) => {
+      if (!generatedWorkout) return;
+
+      const key = String(exerciseIndex);
+      const debounceKey = `${sectionId}:${key}`;
+
+      // Debounce check
+      const now = Date.now();
+      if (now - (lastSwapTime.current[debounceKey] || 0) < DEBOUNCE_MS) return;
+      lastSwapTime.current[debounceKey] = now;
+
+      // Check swap limit
+      if (isSwapDisabled(sectionId, key)) return;
+
+      const section = generatedWorkout.sections.find(s => s.id === sectionId);
+      if (!section) return;
+
+      const currentExercise = section.exercises[exerciseIndex];
+      if (!currentExercise) return;
+
+      setSwapLoading({ sectionId, key });
+      setSwapError(null);
+
+      try {
+        const apiSection = toAPISection(section);
+        const keepExercises = section.exercises
+          .filter((_, i) => i !== exerciseIndex)
+          .map(toAPIExercise);
+
+        // Map section type for API
+        const result = await generateSection({
+          session_context: {
+            intensity: sessionContext.intensity,
+            anchor: sessionContext.anchor,
+            goal: sessionContext.goal,
+            location_id: sessionContext.locationId,
+            equipment: sessionContext.equipment,
+          },
+          section_type: (SECTION_TO_DB[section.type] || section.type) as SectionType,
+          exclude_exercises: sessionContext.excludeExercises,
+          swap_mode: 'single',
+          swap_target: {
+            exercise_name: currentExercise.name,
+          },
+          keep_exercises: keepExercises,
+          current_section: apiSection,
+        });
+
+        if (isGenerationError(result)) {
+          setSwapError({ sectionId, key, message: result.details || result.error });
+          return;
+        }
+
+        // Find the replacement exercise at the same position in the returned section.
+        // The AI returns the full section with one exercise replaced — use position-based
+        // matching since the replaced exercise will have a different ID/name at the same slot.
+        const newApiExercises = result.section.exercises;
+        const replacementApi = newApiExercises[exerciseIndex] || newApiExercises.find(
+          e => e.exercise_id !== currentExercise.id && e.name !== currentExercise.name
+        );
+
+        if (!replacementApi) {
+          setSwapError({ sectionId, key, message: 'No replacement found in response' });
+          return;
+        }
+
+        // Convert to frontend Exercise
+        const replacementExercise = apiExerciseToFrontend(replacementApi);
+
+        // Update swap state (history)
+        setSwapState(prev => {
+          const sectionState = prev[sectionId] || {};
+          const slot = sectionState[key] || { current: currentExercise, history: [], swapCount: 0 };
+          const newHistory = [slot.current, ...slot.history].slice(0, MAX_SWAPS);
+
+          return {
+            ...prev,
+            [sectionId]: {
+              ...sectionState,
+              [key]: {
+                current: replacementExercise,
+                history: newHistory,
+                swapCount: slot.swapCount + 1,
+              },
+            },
+          };
+        });
+
+        // Update the workout
+        setGeneratedWorkout(prev => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            sections: prev.sections.map(s =>
+              s.id === sectionId
+                ? {
+                    ...s,
+                    exercises: s.exercises.map((ex, i) =>
+                      i === exerciseIndex ? replacementExercise : ex
+                    ),
+                  }
+                : s
+            ),
+          };
+        });
+      } catch (err) {
+        setSwapError({
+          sectionId,
+          key,
+          message: err instanceof Error ? err.message : 'Swap failed',
+        });
+      } finally {
+        setSwapLoading(null);
+      }
+    },
+    [generatedWorkout, isSwapDisabled, setGeneratedWorkout, toAPISection]
+  );
+
+  const performUnitSwap = useCallback(
+    async (
+      sectionId: string,
+      groupId: string,
+      structureType: string,
+      sessionContext: SwapSessionContext
+    ) => {
+      if (!generatedWorkout) return;
+
+      const key = groupId;
+      const debounceKey = `${sectionId}:${key}`;
+
+      // Debounce check
+      const now = Date.now();
+      if (now - (lastSwapTime.current[debounceKey] || 0) < DEBOUNCE_MS) return;
+      lastSwapTime.current[debounceKey] = now;
+
+      // Check swap limit
+      if (isSwapDisabled(sectionId, key)) return;
+
+      const section = generatedWorkout.sections.find(s => s.id === sectionId);
+      if (!section) return;
+
+      const groupExercises = section.exercises.filter(
+        ex => ex.structure && 'group_id' in ex.structure && ex.structure.group_id === groupId
+      );
+      if (groupExercises.length === 0) return;
+
+      setSwapLoading({ sectionId, key });
+      setSwapError(null);
+
+      try {
+        const apiSection = toAPISection(section);
+        const keepExercises = section.exercises
+          .filter(ex => !(ex.structure && 'group_id' in ex.structure && ex.structure.group_id === groupId))
+          .map(toAPIExercise);
+
+        const result = await generateSection({
+          session_context: {
+            intensity: sessionContext.intensity,
+            anchor: sessionContext.anchor,
+            goal: sessionContext.goal,
+            location_id: sessionContext.locationId,
+            equipment: sessionContext.equipment,
+          },
+          section_type: (SECTION_TO_DB[section.type] || section.type) as SectionType,
+          exclude_exercises: sessionContext.excludeExercises,
+          swap_mode: 'unit',
+          swap_target: {
+            group_id: groupId,
+            structure_type: structureType,
+          },
+          keep_exercises: keepExercises,
+          current_section: apiSection,
+        });
+
+        if (isGenerationError(result)) {
+          setSwapError({ sectionId, key, message: result.details || result.error });
+          return;
+        }
+
+        // Find replacement exercises (those with different IDs than the originals)
+        const originalIds = new Set(groupExercises.map(e => e.id));
+        const newGroupExercises = result.section.exercises
+          .filter(e => !originalIds.has(e.exercise_id))
+          .map(apiExerciseToFrontend);
+
+        // Update swap state
+        setSwapState(prev => {
+          const sectionState = prev[sectionId] || {};
+          const slot = sectionState[key] || { current: groupExercises, history: [], swapCount: 0 };
+          const newHistory = [slot.current, ...slot.history].slice(0, MAX_SWAPS);
+
+          return {
+            ...prev,
+            [sectionId]: {
+              ...sectionState,
+              [key]: {
+                current: newGroupExercises,
+                history: newHistory,
+                swapCount: slot.swapCount + 1,
+              },
+            },
+          };
+        });
+
+        // Update the workout — replace group exercises in place
+        setGeneratedWorkout(prev => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            sections: prev.sections.map(s => {
+              if (s.id !== sectionId) return s;
+
+              // Build new exercise list: replace group members, keep everything else in position
+              let newGroupIdx = 0;
+              return {
+                ...s,
+                exercises: s.exercises.map(ex => {
+                  if (ex.structure && 'group_id' in ex.structure && ex.structure.group_id === groupId) {
+                    const replacement = newGroupExercises[newGroupIdx];
+                    newGroupIdx++;
+                    return replacement || ex;
+                  }
+                  return ex;
+                }),
+              };
+            }),
+          };
+        });
+      } catch (err) {
+        setSwapError({
+          sectionId,
+          key,
+          message: err instanceof Error ? err.message : 'Swap failed',
+        });
+      } finally {
+        setSwapLoading(null);
+      }
+    },
+    [generatedWorkout, isSwapDisabled, setGeneratedWorkout, toAPISection]
+  );
+
+  const revertToPrevious = useCallback(
+    (sectionId: string, key: string) => {
+      const slot = swapState[sectionId]?.[key];
+      if (!slot || slot.history.length === 0) return;
+
+      const [previous, ...remainingHistory] = slot.history;
+
+      // Update swap state
+      setSwapState(prev => ({
+        ...prev,
+        [sectionId]: {
+          ...prev[sectionId],
+          [key]: {
+            current: previous,
+            history: remainingHistory,
+            swapCount: slot.swapCount, // don't decrement — previous doesn't "undo" a swap count
+          },
+        },
+      }));
+
+      // Update the workout
+      setGeneratedWorkout(prev => {
+        if (!prev) return prev;
+
+        return {
+          ...prev,
+          sections: prev.sections.map(s => {
+            if (s.id !== sectionId) return s;
+
+            if (Array.isArray(previous)) {
+              // Unit swap revert — replace by group_id
+              let prevIdx = 0;
+              const currentGroupExercises = Array.isArray(slot.current) ? slot.current : [slot.current];
+              const currentIds = new Set(currentGroupExercises.map(e => e.id));
+
+              return {
+                ...s,
+                exercises: s.exercises.map(ex => {
+                  if (currentIds.has(ex.id)) {
+                    const replacement = previous[prevIdx];
+                    prevIdx++;
+                    return replacement || ex;
+                  }
+                  return ex;
+                }),
+              };
+            } else {
+              // Single swap revert — replace by index
+              const exerciseIndex = parseInt(key);
+              return {
+                ...s,
+                exercises: s.exercises.map((ex, i) =>
+                  i === exerciseIndex ? previous : ex
+                ),
+              };
+            }
+          }),
+        };
+      });
+    },
+    [swapState, setGeneratedWorkout]
+  );
+
+  return {
+    swapState,
+    swapLoading,
+    swapError,
+    performSwap,
+    performUnitSwap,
+    revertToPrevious,
+    getSwapSlot,
+    isSwapDisabled,
+  };
+}
+
+// ============================================
+// HELPERS
+// ============================================
+
+/** Convert an API GeneratedExercise to a frontend Exercise */
+function apiExerciseToFrontend(apiEx: GeneratedExercise): Exercise {
+  // Map API structure to frontend structure
+  let structure: Exercise['structure'];
+
+  if (apiEx.structure.type === 'afap' || apiEx.structure.type === 'timed') {
+    structure = {
+      type: 'for_time',
+      time_cap_mins: 'time_cap_mins' in apiEx.structure ? apiEx.structure.time_cap_mins : 0,
+      group_id: apiEx.structure.group_id,
+    };
+  } else if (apiEx.structure.type === 'circuit') {
+    structure = {
+      type: 'circuit',
+      circuit_id: apiEx.structure.circuit_id,
+      rounds: 1, // default, will be overridden if present
+      group_id: apiEx.structure.group_id,
+    };
+  } else {
+    structure = apiEx.structure as Exercise['structure'];
+  }
+
+  return {
+    id: apiEx.exercise_id,
+    name: apiEx.name,
+    sets: apiEx.sets,
+    reps: apiEx.reps,
+    effort: apiEx.effort_percent ? `${apiEx.effort_percent}%` : undefined,
+    tempo: apiEx.tempo || undefined,
+    rest: apiEx.rest_seconds ? `${apiEx.rest_seconds}s` : undefined,
+    coachingCues: apiEx.coaching_cues || undefined,
+    regression: apiEx.regression || undefined,
+    equipment: apiEx.equipment || undefined,
+    structure,
+  };
+}

--- a/src/hooks/useWorkoutFlow.ts
+++ b/src/hooks/useWorkoutFlow.ts
@@ -23,6 +23,7 @@ export const useWorkoutFlow = (
     return {
         workoutParams: generation.workoutParams,
         generatedWorkout: generation.generatedWorkout,
+        setGeneratedWorkout: generation.setGeneratedWorkout,
         workoutNotes: session.workoutNotes,
         totalTime: session.totalTime,
         isGenerating: generation.isGenerating,
@@ -30,6 +31,7 @@ export const useWorkoutFlow = (
         currentLocationId: generation.currentLocationId,
         handleGenerate: generation.handleGenerate,
         handleQuickStart: generation.handleQuickStart,
+        cancelGeneration: generation.cancelGeneration,
         handleStartWorkout: session.handleStartWorkout,
         handleFinishWorkout: session.handleFinishWorkout,
         handleFinishSession: session.handleFinishSession,

--- a/src/hooks/useWorkoutGeneration.ts
+++ b/src/hooks/useWorkoutGeneration.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import { toast } from "@/components/ui/sonner";
 import { logger } from "@/lib/logger";
 import {
@@ -27,10 +27,18 @@ export const useWorkoutGeneration = (
     const [isGenerating, setIsGenerating] = useState(false);
     const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
     const [currentLocationId, setCurrentLocationId] = useState<string | null>(null);
+    const cancelledRef = useRef(false);
+
+    const cancelGeneration = useCallback(() => {
+        cancelledRef.current = true;
+        setIsGenerating(false);
+        toast.info("Generation cancelled");
+    }, []);
 
     const handleGenerate = async (params: WorkoutParams, onSuccess?: () => void) => {
         setWorkoutParams(params);
         setIsGenerating(true);
+        cancelledRef.current = false;
 
         try {
             // Parse duration from "45 min" or "45" format
@@ -101,6 +109,9 @@ export const useWorkoutGeneration = (
                 enabled_sections: enabledSections.length > 0 ? enabledSections : undefined,
                 notes: params.notes || undefined,
             });
+
+            // If cancelled while waiting, discard result
+            if (cancelledRef.current) return;
 
             if (isGenerationError(result)) {
                 // Fallback to mock workout on error
@@ -195,5 +206,6 @@ export const useWorkoutGeneration = (
         setCurrentLocationId,
         handleGenerate,
         handleQuickStart,
+        cancelGeneration,
     };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -392,6 +392,7 @@
     --popover: var(--color-neutral-900);
     --popover-foreground: var(--color-neutral-50);
     --primary: var(--color-orange-500);
+    --primary-300: var(--color-orange-300);
     --primary-foreground: var(--color-neutral-50);
     --secondary: var(--color-blue-500);
     --secondary-foreground: var(--color-neutral-50);
@@ -508,6 +509,7 @@
 
     /* Legacy mappings for blue theme */
     --primary: var(--color-blue-500);
+    --primary-300: var(--color-blue-300);
     --accent: var(--color-blue-700);
     --ring: var(--color-blue-500);
     --clear-orange: var(--color-blue-500);

--- a/src/lib/workout-api.ts
+++ b/src/lib/workout-api.ts
@@ -6,6 +6,8 @@ import { logger } from './logger';
 import type {
   GenerateWorkoutRequest,
   GenerateWorkoutResponse,
+  GenerateSectionRequest,
+  GenerateSectionResponse,
   GenerationError,
   GeneratedWorkout as APIGeneratedWorkout,
 } from '@/types/generation';
@@ -52,7 +54,7 @@ export function transformAPIWorkoutToFrontend(
         ? ex.structure.type === 'circuit'
           ? { ...ex.structure, rounds: (ex.structure as { rounds?: number }).rounds || 1 }
           : ex.structure.type === 'afap' || ex.structure.type === 'timed'
-            ? { type: 'for_time' as const, time_cap_mins: ('time_cap_mins' in ex.structure ? ex.structure.time_cap_mins : 0) }
+            ? { type: 'for_time' as const, time_cap_mins: ('time_cap_mins' in ex.structure ? ex.structure.time_cap_mins : 0), group_id: ex.structure.group_id }
             : ex.structure as Exercise['structure']
         : undefined,
     }));
@@ -151,6 +153,61 @@ export async function generateWorkout(
   } catch (err) {
     const durationMs = Math.round(performance.now() - startTime);
     logger.workout.error('generateWorkout exception', {
+      error: err instanceof Error ? err.message : String(err),
+      durationMs,
+    });
+    return {
+      error: 'Network error',
+      details: err instanceof Error ? err.message : 'Unknown error occurred',
+    };
+  }
+}
+
+/**
+ * Generate a replacement section using the AI Edge Function (exercise swap)
+ */
+export async function generateSection(
+  request: GenerateSectionRequest
+): Promise<GenerateSectionResponse | GenerationError> {
+  logger.workout.info('generateSection started', {
+    swapMode: request.swap_mode,
+    sectionType: request.section_type,
+  });
+  const startTime = performance.now();
+
+  try {
+    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+
+    if (sessionError || !session) {
+      logger.workout.error('generateSection: not authenticated');
+      return { error: 'Not authenticated', details: 'Please sign in to swap exercises' };
+    }
+
+    const { data, error } = await supabase.functions.invoke('generate-section', {
+      body: request,
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+      },
+    });
+
+    const durationMs = Math.round(performance.now() - startTime);
+
+    if (error) {
+      const errorMsg = data?.error || error.message || 'Unknown error';
+      logger.workout.error('generateSection error', { error: errorMsg, durationMs });
+      return { error: 'Failed to generate section', details: errorMsg };
+    }
+
+    logger.workout.info('generateSection succeeded', {
+      durationMs,
+      swapMode: request.swap_mode,
+      exerciseCount: data?.section?.exercises?.length,
+    });
+    return data as GenerateSectionResponse;
+
+  } catch (err) {
+    const durationMs = Math.round(performance.now() - startTime);
+    logger.workout.error('generateSection exception', {
       error: err instanceof Error ? err.message : String(err),
       durationMs,
     });

--- a/src/pages/GenerationScreen.tsx
+++ b/src/pages/GenerationScreen.tsx
@@ -8,6 +8,7 @@ import { GoalSelector } from "@/components/GoalSelector";
 import { LocationAccordion } from "@/components/LocationAccordion";
 import { OptionalFields } from "@/components/OptionalFields";
 import { GenerateButton } from "@/components/GenerateButton";
+import { FullscreenLoader } from "@/components/ScanLoader";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useWorkoutFlowContext } from "@/contexts/WorkoutFlowContext";
 import { GoalPreset, INTENSITY_RANGE_BY_GOAL } from "@/types/workout";
@@ -15,7 +16,7 @@ import { GoalPreset, INTENSITY_RANGE_BY_GOAL } from "@/types/workout";
 export const GenerationScreen = () => {
   const navigate = useNavigate();
   const { profile, locations } = useAuthContext();
-  const { handleGenerate: generateWorkout, isGenerating } = useWorkoutFlowContext();
+  const { handleGenerate: generateWorkout, isGenerating, cancelGeneration } = useWorkoutFlowContext();
 
   const defaultLocation = locations.find(
     l => l.id === profile?.defaultLocationId
@@ -57,8 +58,10 @@ export const GenerationScreen = () => {
   const intensityRange = goal ? INTENSITY_RANGE_BY_GOAL[goal] : { min: 1, max: 10 };
 
   return (
+    <>
+    <FullscreenLoader message="GENERATING WORKOUT" visible={isGenerating} onCancel={cancelGeneration} />
     <AppLayout
-      header={<PageHeader right="menu" onMenu={() => navigate("/settings")} />}
+      header={<PageHeader left="back" onBack={() => navigate("/")} right="menu" onMenu={() => navigate("/settings")} />}
       footer={<GenerateButton onClick={handleGenerate} disabled={!canGenerate} isLoading={isGenerating} />}
     >
       <div className="pt-6 space-y-6 stagger-reveal">
@@ -87,5 +90,6 @@ export const GenerationScreen = () => {
         />
       </div>
     </AppLayout>
+    </>
   );
 };

--- a/src/pages/HomeScreen.tsx
+++ b/src/pages/HomeScreen.tsx
@@ -102,11 +102,17 @@ export const HomeScreen = () => {
 
   const handleAbandonIncomplete = async () => {
     if (!incompleteSession) return;
-    await supabase
+    const { error } = await supabase
       .from('workout_sessions')
       .delete()
       .eq('id', incompleteSession.id);
+    if (error) {
+      logger.data.error('Error abandoning incomplete session', { error: error.message });
+      toast.error("Failed to abandon workout");
+      return;
+    }
     clearIncompleteSession();
+    await loadHomeData();
   };
 
   const handleResumeIncomplete = async () => {
@@ -128,7 +134,7 @@ export const HomeScreen = () => {
       <div className="pt-6 space-y-6 stagger-reveal">
         <Card
           onClick={() => navigate("/generate")}
-          padding="lg"
+          padding="md"
           borderColor="var(--border-cta-primary)"
           accentColor="var(--surface-cta-accent)"
           surfaceColor="var(--surface-cta-primary)"

--- a/src/pages/ReviewScreen.tsx
+++ b/src/pages/ReviewScreen.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
 import { toast } from "@/components/ui/sonner";
 import { PageHeader } from "@/components/PageHeader";
@@ -6,19 +7,132 @@ import { WorkoutOverview } from "@/components/WorkoutOverview";
 import { WorkoutSectionCard } from "@/components/WorkoutSectionCard";
 import { StartWorkoutButton } from "@/components/StartWorkoutButton";
 import { useWorkoutFlowContext } from "@/contexts/WorkoutFlowContext";
+import { useExerciseSwap, type SwapSessionContext } from "@/hooks/useExerciseSwap";
+
+const MAX_SWAPS = 3;
 
 export const ReviewScreen = () => {
   const navigate = useNavigate();
-  const { generatedWorkout, handleStartWorkout } = useWorkoutFlowContext();
+  const {
+    generatedWorkout,
+    setGeneratedWorkout,
+    handleStartWorkout,
+    workoutParams,
+    currentLocationId,
+  } = useWorkoutFlowContext();
+
+  const {
+    swapLoading,
+    swapError,
+    performSwap,
+    performUnitSwap,
+    revertToPrevious,
+    getSwapSlot,
+    isSwapDisabled,
+  } = useExerciseSwap(generatedWorkout, setGeneratedWorkout);
 
   if (!generatedWorkout) {
     return <Navigate to="/generate" replace />;
   }
 
-  const handleRandomizeSection = (sectionId: string) => {
-    toast.info("Section randomized", {
-      description: `${sectionId} has been regenerated`,
+  // Build session context for swap API calls
+  const sessionContext: SwapSessionContext = useMemo(() => {
+    // Collect all exercise IDs across sections (for exclude_exercises)
+    const allExerciseIds = generatedWorkout.sections.flatMap(
+      s => s.exercises.map(e => e.id)
+    );
+
+    return {
+      intensity: generatedWorkout.intensity,
+      anchor: generatedWorkout.anchor,
+      goal: generatedWorkout.goal,
+      locationId: currentLocationId || undefined,
+      excludeExercises: allExerciseIds,
+    };
+  }, [generatedWorkout, currentLocationId]);
+
+  // Build swap control props for each section
+  const buildExerciseSwapControls = (sectionId: string, exercises: typeof generatedWorkout.sections[0]['exercises']) => {
+    const controls: Record<number, any> = {};
+
+    exercises.forEach((exercise, index) => {
+      const structure = exercise.structure;
+      const isStandard = !structure || structure.type === 'standard';
+      const isCircuit = structure?.type === 'circuit';
+
+      // Only show swap controls on standard + circuit exercises
+      if (!isStandard && !isCircuit) return;
+
+      const key = String(index);
+      const slot = getSwapSlot(sectionId, key);
+      const loading = swapLoading?.sectionId === sectionId && swapLoading?.key === key;
+      const error = swapError?.sectionId === sectionId && swapError?.key === key
+        ? swapError.message : null;
+
+      controls[index] = {
+        onSwap: () => {
+          if (isSwapDisabled(sectionId, key)) {
+            toast.info("Nothing feeling right? Try regenerating with different inputs.", {
+              action: {
+                label: "Regenerate Workout",
+                onClick: () => navigate("/generate"),
+              },
+            });
+            return;
+          }
+          performSwap(sectionId, index, sessionContext);
+        },
+        onPrevious: () => revertToPrevious(sectionId, key),
+        isSwapLoading: loading,
+        isSwapDisabled: isSwapDisabled(sectionId, key),
+        hasPrevious: (slot?.history?.length ?? 0) > 0,
+        swapError: error,
+        showSwapControls: true,
+      };
     });
+
+    return controls;
+  };
+
+  const buildGroupSwapControls = (sectionId: string, exercises: typeof generatedWorkout.sections[0]['exercises']) => {
+    const controls: Record<string, any> = {};
+    const seenGroups = new Set<string>();
+
+    exercises.forEach((exercise) => {
+      const structure = exercise.structure;
+      if (!structure || structure.type === 'standard' || structure.type === 'circuit') return;
+
+      const groupId = 'group_id' in structure ? structure.group_id : undefined;
+      if (!groupId || seenGroups.has(groupId)) return;
+      seenGroups.add(groupId);
+
+      const slot = getSwapSlot(sectionId, groupId);
+      const loading = swapLoading?.sectionId === sectionId && swapLoading?.key === groupId;
+
+      const swapLabel = structure.type === 'superset' ? 'Swap Pair' : 'Swap Block';
+
+      controls[groupId] = {
+        onSwap: () => {
+          if (isSwapDisabled(sectionId, groupId)) {
+            toast.info("Nothing feeling right? Try regenerating with different inputs.", {
+              action: {
+                label: "Regenerate Workout",
+                onClick: () => navigate("/generate"),
+              },
+            });
+            return;
+          }
+          performUnitSwap(sectionId, groupId, structure.type, sessionContext);
+        },
+        onPrevious: () => revertToPrevious(sectionId, groupId),
+        isSwapLoading: loading,
+        isSwapDisabled: isSwapDisabled(sectionId, groupId),
+        hasPrevious: (slot?.history?.length ?? 0) > 0,
+        label: swapLabel,
+      };
+    });
+
+    return controls;
   };
 
   return (
@@ -34,7 +148,8 @@ export const ReviewScreen = () => {
             <WorkoutSectionCard
               key={section.id}
               section={section}
-              onRandomize={() => handleRandomizeSection(section.name)}
+              exerciseSwapControls={buildExerciseSwapControls(section.id, section.exercises)}
+              groupSwapControls={buildGroupSwapControls(section.id, section.exercises)}
             />
           ))}
         </div>

--- a/src/routes/guards.tsx
+++ b/src/routes/guards.tsx
@@ -1,6 +1,8 @@
+import { useState, useCallback } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useAuthContext } from '@/contexts/AuthContext';
+import { BootScreen } from '@/components/ScanLoader';
 import { LoadingScreen } from '@/components/LoadingScreen';
 import { RouteErrorFallback } from '@/components/RouteErrorFallback';
 import { RouteTransition } from '@/components/RouteTransition';
@@ -8,13 +10,25 @@ import { RouteTransition } from '@/components/RouteTransition';
 /**
  * Wraps authenticated routes. Redirects to /welcome if unauthenticated,
  * /onboarding if authenticated but not onboarded.
+ * Shows boot sequence while auth resolves.
  */
 export function ProtectedRoute() {
   const { status, profile } = useAuthContext();
   const location = useLocation();
+  const [bootComplete, setBootComplete] = useState(false);
 
-  if (status === 'loading') {
-    return <LoadingScreen subtitle="Initializing..." />;
+  const handleBootComplete = useCallback(() => {
+    setBootComplete(true);
+  }, []);
+
+  // Show boot sequence while loading OR while boot animation hasn't finished
+  if (status === 'loading' || !bootComplete) {
+    return (
+      <BootScreen
+        ready={status !== 'loading'}
+        onComplete={handleBootComplete}
+      />
+    );
   }
 
   if (status === 'unauthenticated') {

--- a/src/types/generation.ts
+++ b/src/types/generation.ts
@@ -82,12 +82,12 @@ export interface GeneratedExercise {
 
 export type ExerciseStructure =
   | { type: 'standard' }
-  | { type: 'superset'; paired_with: string }
-  | { type: 'circuit'; circuit_id: string }
-  | { type: 'emom'; minutes: number }
-  | { type: 'amrap'; minutes: number }
-  | { type: 'afap'; time_cap_mins: number; pattern: string }
-  | { type: 'timed'; work_seconds: number; rest_seconds: number };
+  | { type: 'superset'; paired_with: string; group_id: string }
+  | { type: 'circuit'; circuit_id: string; group_id: string }
+  | { type: 'emom'; minutes: number; group_id: string }
+  | { type: 'amrap'; minutes: number; group_id: string }
+  | { type: 'afap'; time_cap_mins: number; pattern: string; group_id: string }
+  | { type: 'timed'; work_seconds: number; rest_seconds: number; group_id: string };
 
 export type SectionType =
   | 'warmup'
@@ -97,6 +97,41 @@ export type SectionType =
   | 'core'
   | 'conditioning'
   | 'cooldown';
+
+// ============================================
+// SWAP / SECTION GENERATION TYPES
+// ============================================
+
+export interface SwapTarget {
+  exercise_name?: string;
+  group_id?: string;
+  structure_type?: 'superset' | 'emom' | 'amrap' | 'afap' | 'timed';
+}
+
+export interface GenerateSectionRequest {
+  session_context: {
+    intensity: number;
+    anchor: string;
+    goal?: string;
+    location_id?: string;
+    equipment?: string[];
+  };
+  section_type: SectionType;
+  exclude_exercises?: string[];
+  swap_mode: 'section' | 'single' | 'unit';
+  swap_target: SwapTarget;
+  keep_exercises: GeneratedExercise[];
+  current_section: GeneratedSection;
+}
+
+export interface GenerateSectionResponse {
+  section: GeneratedSection;
+  metadata: {
+    swap_mode: string;
+    swap_target: SwapTarget;
+    generated_at: string;
+  };
+}
 
 // ============================================
 // ERROR TYPES
@@ -119,36 +154,36 @@ export function isGenerationError(
 
 export function isStructureSuperset(
   structure: ExerciseStructure
-): structure is { type: 'superset'; paired_with: string } {
+): structure is { type: 'superset'; paired_with: string; group_id: string } {
   return structure.type === 'superset';
 }
 
 export function isStructureCircuit(
   structure: ExerciseStructure
-): structure is { type: 'circuit'; circuit_id: string } {
+): structure is { type: 'circuit'; circuit_id: string; group_id: string } {
   return structure.type === 'circuit';
 }
 
 export function isStructureEmom(
   structure: ExerciseStructure
-): structure is { type: 'emom'; minutes: number } {
+): structure is { type: 'emom'; minutes: number; group_id: string } {
   return structure.type === 'emom';
 }
 
 export function isStructureAmrap(
   structure: ExerciseStructure
-): structure is { type: 'amrap'; minutes: number } {
+): structure is { type: 'amrap'; minutes: number; group_id: string } {
   return structure.type === 'amrap';
 }
 
 export function isStructureAfap(
   structure: ExerciseStructure
-): structure is { type: 'afap'; time_cap_mins: number; pattern: string } {
+): structure is { type: 'afap'; time_cap_mins: number; pattern: string; group_id: string } {
   return structure.type === 'afap';
 }
 
 export function isStructureTimed(
   structure: ExerciseStructure
-): structure is { type: 'timed'; work_seconds: number; rest_seconds: number } {
+): structure is { type: 'timed'; work_seconds: number; rest_seconds: number; group_id: string } {
   return structure.type === 'timed';
 }

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -127,11 +127,11 @@ export interface UserPreferences {
 
 export type ExerciseStructure =
   | { type: 'standard' }
-  | { type: 'superset'; paired_with: string }
-  | { type: 'circuit'; circuit_id: string; rounds: number }
-  | { type: 'emom'; minutes: number }
-  | { type: 'amrap'; minutes: number }
-  | { type: 'for_time'; time_cap_mins: number };
+  | { type: 'superset'; paired_with: string; group_id: string }
+  | { type: 'circuit'; circuit_id: string; rounds: number; group_id: string }
+  | { type: 'emom'; minutes: number; group_id: string }
+  | { type: 'amrap'; minutes: number; group_id: string }
+  | { type: 'for_time'; time_cap_mins: number; group_id: string };
 
 export interface StructureResult {
   id: string;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -370,6 +370,9 @@ ANTHROPIC_API_KEY = "env(ANTHROPIC_API_KEY)"
 [functions.generate-workout]
 verify_jwt = false
 
+[functions.generate-section]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/generate-section/index.ts
+++ b/supabase/functions/generate-section/index.ts
@@ -1,0 +1,501 @@
+// Supabase Edge Function: generate-section
+// Handles exercise swap operations for the Review screen (Screen 2)
+// Supports single exercise swap, unit swap, and full section regeneration
+// Version: v1.0.0
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from '@supabase/supabase-js';
+
+// ============================================
+// TYPES
+// ============================================
+
+interface SwapTarget {
+  exercise_name?: string;   // for single swap
+  group_id?: string;        // for unit swap
+  structure_type?: string;  // 'superset' | 'emom' | 'amrap' | 'afap' | 'timed'
+}
+
+interface ExerciseStructure {
+  type: 'standard' | 'superset' | 'circuit' | 'emom' | 'amrap' | 'for_time';
+  paired_with?: string;
+  circuit_id?: string;
+  group_id?: string;
+  rounds?: number;
+  minutes?: number;
+  time_cap_mins?: number;
+}
+
+interface GeneratedExercise {
+  exercise_id: string;
+  name: string;
+  equipment: string;
+  sets: number | null;
+  reps: string;
+  effort_percent: number | null;
+  tempo: string | null;
+  rest_seconds: number | null;
+  coaching_cues: string[];
+  regression: string | null;
+  structure: ExerciseStructure;
+}
+
+interface GeneratedSection {
+  section_type: string;
+  section_title: string;
+  section_notes: string | null;
+  estimated_duration_mins: number;
+  exercises: GeneratedExercise[];
+}
+
+interface SwapRequest {
+  session_context: {
+    intensity: number;
+    anchor: string;
+    goal?: string;
+    location_id?: string;
+    equipment?: string[];
+  };
+  section_type: string;
+  exclude_exercises?: string[];
+  swap_mode: 'section' | 'single' | 'unit';
+  swap_target: SwapTarget;
+  keep_exercises: GeneratedExercise[];
+  current_section: GeneratedSection;
+}
+
+interface ExerciseDefinition {
+  id: string;
+  name: string;
+  equipment_options: string[];
+  sections: string[];
+  coaching_cues: string[] | null;
+  regression: string | null;
+  can_be_primary: boolean;
+  anchors: string[] | null;
+}
+
+// ============================================
+// PROMPT BUILDERS
+// ============================================
+
+function buildSwapSystemPrompt(): string {
+  return `You are a fitness coach assisting with exercise swaps in the Clear app. You will receive a section from a workout and instructions on what to replace. Your job is to return the FULL section with the replacement(s) made.
+
+RULES:
+1. Only replace what is asked — preserve everything else exactly
+2. The replacement must fit the same role in the section
+3. Never duplicate an exercise that's staying in the section or listed in exclude_exercises
+4. Match the intensity level and available equipment
+5. Maintain the same structure type for unit swaps (if replacing an AMRAP, return an AMRAP)
+6. All non-standard exercises MUST include group_id in their structure. Exercises in the same group share the same group_id.
+7. Use ONLY exercise_id values from the provided exercise library
+8. Return valid JSON matching the section schema — no markdown, no explanation
+
+OUTPUT FORMAT:
+{
+  "section_type": "string",
+  "section_title": "string",
+  "section_notes": "string|null",
+  "estimated_duration_mins": number,
+  "exercises": [
+    {
+      "exercise_id": "string - MUST be from exercise library",
+      "name": "string",
+      "equipment": "string",
+      "sets": number|null,
+      "reps": "string",
+      "effort_percent": number|null,
+      "tempo": "string|null",
+      "rest_seconds": number|null,
+      "coaching_cues": ["array"],
+      "regression": "string|null",
+      "structure": { "type": "standard|superset|circuit|emom|amrap|for_time|timed", "group_id": "string (required for non-standard)", ...params }
+    }
+  ]
+}`;
+}
+
+function buildSwapUserPrompt(
+  request: SwapRequest,
+  equipment: string[],
+  exerciseLibrary: ExerciseDefinition[]
+): string {
+  const { swap_mode, swap_target, keep_exercises, current_section, session_context, exclude_exercises } = request;
+
+  const keepNames = keep_exercises.map(e => e.name).join(', ') || 'None';
+  const excludeNames = (exclude_exercises || []).join(', ') || 'None';
+  const equipmentStr = equipment.join(', ');
+
+  // Build exercise library for the prompt
+  const exerciseListStr = exerciseLibrary.map(ex => {
+    const equipStr = ex.equipment_options.join(', ');
+    const sectionsStr = ex.sections.join(', ');
+    const anchorsStr = ex.anchors?.length ? ` anchors:[${ex.anchors.join(', ')}]` : '';
+    return `  ${ex.id} | ${ex.name} | equipment:[${equipStr}] | sections:[${sectionsStr}]${anchorsStr}`;
+  }).join('\n');
+
+  let swapInstructions = '';
+
+  if (swap_mode === 'single') {
+    // Check if the target exercise is in a circuit
+    const targetExercise = current_section.exercises.find(
+      e => e.name === swap_target.exercise_name
+    );
+    const isCircuit = targetExercise?.structure?.type === 'circuit';
+
+    if (isCircuit) {
+      const circuitId = targetExercise.structure.circuit_id || targetExercise.structure.group_id;
+      const otherCircuitExercises = current_section.exercises
+        .filter(e =>
+          e.name !== swap_target.exercise_name &&
+          (e.structure?.circuit_id === circuitId || e.structure?.group_id === circuitId)
+        )
+        .map(e => e.name)
+        .join(', ');
+      const otherSectionExercises = current_section.exercises
+        .filter(e =>
+          e.name !== swap_target.exercise_name &&
+          e.structure?.circuit_id !== circuitId &&
+          e.structure?.group_id !== circuitId
+        )
+        .map(e => e.name)
+        .join(', ') || 'None';
+
+      swapInstructions = `SWAP MODE: single (within circuit)
+Replace ONLY "${swap_target.exercise_name}" in this circuit.
+Other circuit exercises (the replacement must complement these): ${otherCircuitExercises}
+Other section exercises (do not duplicate): ${otherSectionExercises}
+The replacement should:
+- Fit the circuit's flow and intent
+- Use available equipment: ${equipmentStr}
+- Maintain similar work/rest timing
+Return the full section with ONE circuit exercise replaced.`;
+    } else {
+      swapInstructions = `SWAP MODE: single
+Replace ONLY "${swap_target.exercise_name}" in this section.
+Exercises staying (do not duplicate these): ${keepNames}
+The replacement should:
+- Fit the same role in the section
+- Use available equipment: ${equipmentStr}
+- Match intensity level: ${session_context.intensity}/10
+- Not duplicate any exercise in the full workout
+Return the full section with ONE exercise replaced.`;
+    }
+  } else if (swap_mode === 'unit') {
+    const groupExercises = current_section.exercises
+      .filter(e => e.structure?.group_id === swap_target.group_id)
+      .map(e => e.name)
+      .join(', ');
+    const otherSectionExercises = current_section.exercises
+      .filter(e => e.structure?.group_id !== swap_target.group_id)
+      .map(e => e.name)
+      .join(', ') || 'None';
+
+    swapInstructions = `SWAP MODE: unit
+Replace the entire ${swap_target.structure_type} group: ${groupExercises}
+Other exercises in this section (do not duplicate): ${otherSectionExercises}
+The replacement group should:
+- Serve the same training purpose as the original group
+- Maintain the same structure type (${swap_target.structure_type})
+- Use available equipment: ${equipmentStr}
+- Match intensity level: ${session_context.intensity}/10
+Return the full section with the group replaced.`;
+  } else {
+    // section mode — regenerate entire section
+    swapInstructions = `SWAP MODE: section
+Regenerate the entire "${current_section.section_title}" section.
+The replacement section should:
+- Serve the same purpose (${request.section_type})
+- Use available equipment: ${equipmentStr}
+- Match intensity level: ${session_context.intensity}/10
+- Not duplicate exercises from other sections
+Return a completely new section.`;
+  }
+
+  return `${swapInstructions}
+
+CONTEXT:
+- Anchor: ${session_context.anchor}
+- Goal: ${session_context.goal || 'balanced'}
+- Intensity: ${session_context.intensity}/10
+- Section type: ${request.section_type}
+- Exercises to exclude (from other sections): ${excludeNames}
+
+CURRENT SECTION:
+${JSON.stringify(current_section, null, 2)}
+
+EXERCISE LIBRARY (you MUST only use exercise_id values from this list):
+${exerciseListStr}
+
+Return the full updated section as JSON only.`;
+}
+
+// ============================================
+// HELPERS
+// ============================================
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+  });
+}
+
+async function callClaudeAPI(
+  systemPrompt: string,
+  userPrompt: string
+): Promise<GeneratedSection> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY not configured');
+  }
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Claude API error: ${response.status} - ${error}`);
+  }
+
+  const result = await response.json();
+  const content = result.content[0]?.text;
+
+  if (!content) {
+    throw new Error('Empty response from Claude API');
+  }
+
+  // Parse JSON — strip markdown code fences if present
+  let jsonContent = content.trim();
+  if (jsonContent.startsWith('```')) {
+    jsonContent = jsonContent.replace(/^```(?:json)?\s*\n?/, '');
+    jsonContent = jsonContent.replace(/\n?```\s*$/, '');
+  }
+
+  try {
+    return JSON.parse(jsonContent);
+  } catch {
+    throw new Error(`Failed to parse Claude response as JSON: ${jsonContent.substring(0, 200)}...`);
+  }
+}
+
+function validateSection(
+  section: GeneratedSection,
+  exerciseLibrary: Set<string>,
+  availableEquipment: Set<string>,
+  request: SwapRequest
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  for (const exercise of section.exercises) {
+    if (!exerciseLibrary.has(exercise.exercise_id)) {
+      errors.push(`Unknown exercise_id: ${exercise.exercise_id}`);
+    }
+    if (!availableEquipment.has(exercise.equipment)) {
+      errors.push(`Unavailable equipment: ${exercise.equipment} for "${exercise.name}"`);
+    }
+    // Validate group_id on non-standard structures
+    if (exercise.structure?.type !== 'standard' && !exercise.structure?.group_id) {
+      errors.push(`Missing group_id on non-standard exercise: "${exercise.name}"`);
+    }
+  }
+
+  // For unit swaps, verify structure type is maintained
+  if (request.swap_mode === 'unit' && request.swap_target.structure_type) {
+    const replacementExercises = section.exercises.filter(
+      e => e.structure?.group_id && e.structure.group_id !== request.swap_target.group_id
+    );
+    // Check new group has the correct structure type
+    const newGroupExercises = section.exercises.filter(
+      e => e.structure?.group_id &&
+        !request.keep_exercises.some(k => k.exercise_id === e.exercise_id)
+    );
+    for (const ex of newGroupExercises) {
+      if (ex.structure?.type !== request.swap_target.structure_type) {
+        errors.push(
+          `Structure type mismatch: expected ${request.swap_target.structure_type}, got ${ex.structure?.type} for "${ex.name}"`
+        );
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ============================================
+// MAIN HANDLER
+// ============================================
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: CORS_HEADERS });
+  }
+
+  try {
+    const request: SwapRequest = await req.json();
+
+    // Validate required fields
+    if (!request.swap_mode || !request.session_context || !request.current_section) {
+      return jsonResponse(
+        { error: 'Missing required fields: swap_mode, session_context, current_section' },
+        400
+      );
+    }
+
+    if (request.swap_mode === 'single' && !request.swap_target?.exercise_name) {
+      return jsonResponse(
+        { error: 'Single swap requires swap_target.exercise_name' },
+        400
+      );
+    }
+
+    if (request.swap_mode === 'unit' && !request.swap_target?.group_id) {
+      return jsonResponse(
+        { error: 'Unit swap requires swap_target.group_id' },
+        400
+      );
+    }
+
+    // Auth
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const authHeader = req.headers.get('Authorization');
+
+    if (!authHeader) {
+      return jsonResponse({ error: 'Authorization required' }, 401);
+    }
+
+    const supabaseAuth = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: { user }, error: authError } = await supabaseAuth.auth.getUser();
+
+    if (authError || !user) {
+      return jsonResponse({ error: 'Invalid or expired token' }, 401);
+    }
+
+    // Service client for DB reads
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Get equipment
+    let equipment: string[];
+
+    if (request.session_context.location_id) {
+      const { data: location, error: locError } = await supabase
+        .from('locations')
+        .select('equipment')
+        .eq('id', request.session_context.location_id)
+        .eq('user_id', user.id)
+        .single();
+
+      if (locError || !location) {
+        return jsonResponse({ error: 'Location not found' }, 404);
+      }
+      equipment = [...location.equipment, 'bodyweight'];
+    } else if (request.session_context.equipment) {
+      equipment = [...request.session_context.equipment, 'bodyweight'];
+    } else {
+      return jsonResponse({ error: 'Must provide location_id or equipment' }, 400);
+    }
+
+    // Fetch exercise library filtered to available equipment and section type
+    const { data: exerciseDefinitions } = await supabase
+      .from('exercise_definitions_with_anchors')
+      .select('id, name, equipment_options, sections, coaching_cues, regression, can_be_primary, anchors');
+
+    const availableEquipmentSet = new Set(equipment);
+
+    const availableExercises = (exerciseDefinitions || []).filter((ex: any) => {
+      const hasEquipment = (ex.equipment_options || []).some((eq: string) =>
+        availableEquipmentSet.has(eq)
+      );
+      const hasSection = (ex.sections || []).some((s: string) =>
+        s === request.section_type
+      );
+      return hasEquipment && hasSection;
+    }) as ExerciseDefinition[];
+
+    const exerciseLibrarySet = new Set((exerciseDefinitions || []).map((e: any) => e.id));
+
+    // Build prompts
+    const systemPrompt = buildSwapSystemPrompt();
+    const userPrompt = buildSwapUserPrompt(request, equipment, availableExercises);
+
+    // Call Claude API with retry
+    let section: GeneratedSection;
+    let retryCount = 0;
+    const maxRetries = 1;
+
+    while (true) {
+      try {
+        section = await callClaudeAPI(systemPrompt, userPrompt);
+
+        const validation = validateSection(
+          section,
+          exerciseLibrarySet,
+          availableEquipmentSet,
+          request
+        );
+
+        if (validation.valid) {
+          break;
+        }
+
+        if (retryCount >= maxRetries) {
+          console.warn('Validation errors after retry:', validation.errors);
+          break;
+        }
+
+        retryCount++;
+        console.warn(`Validation failed, retrying (${retryCount}/${maxRetries}):`, validation.errors);
+      } catch (error) {
+        if (retryCount >= maxRetries) {
+          throw error;
+        }
+        retryCount++;
+        console.warn(`Generation failed, retrying (${retryCount}/${maxRetries}):`, error);
+      }
+    }
+
+    return jsonResponse({
+      section,
+      metadata: {
+        swap_mode: request.swap_mode,
+        swap_target: request.swap_target,
+        generated_at: new Date().toISOString(),
+      },
+    });
+
+  } catch (error) {
+    console.error('Error in generate-section:', error);
+
+    return jsonResponse(
+      {
+        error: 'Failed to generate section',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      500
+    );
+  }
+});

--- a/supabase/functions/generate-workout/index.ts
+++ b/supabase/functions/generate-workout/index.ts
@@ -39,6 +39,7 @@ interface ExerciseStructure {
   type: 'standard' | 'superset' | 'circuit' | 'emom' | 'amrap' | 'for_time';
   paired_with?: string;
   circuit_id?: string;
+  group_id?: string;
   rounds?: number;
   minutes?: number;
   time_cap_mins?: number;

--- a/supabase/functions/generate-workout/prompt.ts
+++ b/supabase/functions/generate-workout/prompt.ts
@@ -95,30 +95,36 @@ superset
 - Use for: Accessory, core (for efficiency or added intensity)
 - Best pairings: Antagonist muscles (push/pull, biceps/triceps), non-competing muscle groups (upper/lower), or same muscle group for intensity (agonist superset)
 - BAD pairings: Two exercises that compete for the same stabilizers (e.g., bench press + overhead press), or two exercises that require different fixed equipment (e.g., cable row + lat pulldown)
-- Parameters: { type: 'superset', paired_with: 'exercise-id' }
+- Parameters: { type: 'superset', paired_with: 'exercise-id', group_id: 'unique-group-id' }
 
 circuit
 - What: 3+ exercises in sequence, prescribed rounds, rest after each round
 - Use for: Conditioning (primary), accessory (for efficiency)
 - Movement flow: Order exercises so transitions are smooth. Prefer: standing → standing → floor, or barbell → bodyweight → KB. Avoid: floor → barbell → floor (too much setup/teardown). If using one piece of equipment, keep it for consecutive exercises.
-- Parameters: { type: 'circuit', circuit_id: 'unique-id', rounds: 3 }
+- Parameters: { type: 'circuit', circuit_id: 'unique-id', group_id: 'unique-group-id', rounds: 3 }
 
 emom
 - What: Fixed work at top of each minute, remaining time is rest
 - Use for: Conditioning, accessory, skill work (NOT warm-up or cooldown)
 - Minute allocation: 1-2 movements per minute. If 2, alternate minutes (odd/even). Don't cram 3+ movements into one minute — use circuit instead.
-- Parameters: { type: 'emom', minutes: 8 }
+- Parameters: { type: 'emom', minutes: 8, group_id: 'unique-group-id' }
 
 amrap
 - What: Fixed time, goal is maximum rounds completed
 - Use for: Conditioning
 - Movement count: 2-4 movements per round. More than 4 loses the "how many rounds" signal.
-- Parameters: { type: 'amrap', minutes: 8 }
+- Parameters: { type: 'amrap', minutes: 8, group_id: 'unique-group-id' }
 
 for_time
 - What: Fixed work, goal is fast completion, always has time cap
 - Use for: Conditioning
-- Parameters: { type: 'for_time', time_cap_mins: 8 }
+- Parameters: { type: 'for_time', time_cap_mins: 8, group_id: 'unique-group-id' }
+
+IMPORTANT: group_id rules
+- Every non-standard structure MUST include a group_id string
+- All exercises that belong to the same group (superset pair, circuit, EMOM block, AMRAP block, For Time block) MUST share the same group_id
+- Use a unique, descriptive ID per group (e.g., 'superset-1', 'circuit-conditioning-1', 'emom-1')
+- Standard exercises do NOT get a group_id
 
 ---
 
@@ -370,7 +376,7 @@ Return valid JSON matching this exact schema. No markdown, no explanation — ju
           "rest_seconds": number|null,
           "coaching_cues": ["array of coaching cue strings"],
           "regression": "string|null - easier alternative",
-          "structure": { "type": "standard|superset|circuit|emom|amrap|for_time|timed", ...params }
+          "structure": { "type": "standard|superset|circuit|emom|amrap|for_time|timed", "group_id": "string (required for all non-standard types, same for exercises in the same group)", ...params }
         }
       ]
     }


### PR DESCRIPTION
## Summary
- **Exercise swap**: Per-exercise and unit-level (superset/block) swap via new `generate-section` edge function with swap history and undo support
- **ScanLoader system**: Boot screen with interruptible sweep sequence, fullscreen generation overlay with cancel button, and card-level bounce loader for swap animations
- **CRT static aesthetic**: 300-level primary color pixel rendering, bounce fill/clear loop, theme-aware canvas drawing with DPR support
- **Cancel generation**: Abort button on fullscreen loader using secondary chamfered CTA, dismisses in-flight workout generation
- **UI polish**: Exercise title size reduction (h6 → label-md), location text CTA color, accordion persistence through swaps, padding alignment fixes

## Test plan
- [ ] Generate a workout and verify the fullscreen scan loader appears with bounce animation
- [ ] Cancel mid-generation and verify it dismisses cleanly
- [ ] Expand an exercise card → swap → verify card stays expanded and card loader bounces
- [ ] Use undo (previous) after swap to restore prior exercise
- [ ] Swap a superset/block unit and verify group-level loader
- [ ] Toggle theme (orange ↔ blue) and verify scan pixels use 300-level primary, cancel button swaps CTA color
- [ ] Verify boot screen plays on app load and exits cleanly when auth resolves
- [ ] Check exercise titles are smaller than before (16px vs 20px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)