### PR TITLE
Remove coaching cues from generation, fix duplicate section save bug

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -142,6 +142,18 @@ New functionality to build.
   - Added: 2026-03-05
   - Context: Split from original exercise edit/swap/randomize item. Swap is done; inline edit would be client-only changes to the generated workout before starting.
 
+- [ ] **1 Rep Max testing mode** - Dedicated workout mode for testing true 1RM on compound lifts
+  - Priority: Low
+  - Type: Feature
+  - Added: 2026-03-05
+  - Context: Separate goal/mode for maximal strength testing. Would need warmup ramp-up sets, attempt tracking, rest period guidance (3-5 min), and history to track PR progression over time.
+
+- [ ] **Progressive loading for strength workouts** - Add a progressive load section to strength-focused workouts
+  - Priority: Low
+  - Type: Feature
+  - Added: 2026-03-05
+  - Context: Strength training benefits from structured warm-up/ramp-up sets building toward working weight. Could be a new section type or integrated into primary_lift section with ascending load percentages (e.g., bar only → 50% → 70% → 85% → working sets).
+
 - [ ]
 
 ---

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -85,6 +85,12 @@ Important but not blocking. Address after core features complete.
 ### Low Priority
 Nice to have. Address when time permits or for future versions.
 
+- [ ] **Re-enable coaching cues in generation** - Add `coaching_cues` back to output schema in prompt files
+  - Priority: Low
+  - Type: Enhancement
+  - Added: 2026-03-05
+  - Context: Removed from `generate-workout/prompt.ts` and `generate-section/index.ts` output schemas to reduce output tokens and speed up generation. Regression was kept. To restore: add `"coaching_cues": ["array of coaching cue strings"],` back to each prompt's output schema. Frontend (`ExerciseCard.tsx`) already renders them conditionally — no UI changes needed. DB column still exists.
+
 - [ ] **Superset connector spacing** - Horizontal gap between vertical connector line and exercise text needs fine-tuning
   - Priority: Low
   - Type: Enhancement

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-03-05 (8th session)
+**Last Session:** 2026-03-05 (9th session)
 
 ---
 
@@ -13,14 +13,53 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** Feature — exercise swap, scan loader system, UI polish
-**Current Task:** Complete — merged PR #14 to main
-**Last Completed:** Exercise swap, ScanLoader system (boot/fullscreen/card), cancel generation, CRT static aesthetic, UI polish
-**Blocking Issues:** None — on main, clean state
+**Current Phase:** Optimization — generation speed, DB constraint fix
+**Current Task:** Complete — coaching cues removed, section type constraint dropped
+**Last Completed:** Coaching cues output reduction, duplicate section type constraint fix, generation speed plan evaluation
+**Blocking Issues:** None — changes on main, need commit + PR
 
 ---
 
 ## Session Entries
+
+### Session: 2026-03-05 - Generation Speed + Save Bug Fix
+
+**Duration:** ~45 min
+**Mode:** Claude Code
+**Branch:** `main` (direct, uncommitted)
+
+#### What Got Done
+- **Coaching cues removed from generation output**: Dropped `coaching_cues` from output schema in both `generate-workout/prompt.ts` and `generate-section/index.ts`. Reduces output tokens by 300-750 per workout (30-50 tokens per exercise × 10-15 exercises). Frontend transform and DB save updated to pass null/empty. UI already handles absence gracefully.
+- **Workout save bug fixed**: `idx_workout_sections_unique_type` constraint on `(session_id, section_type)` was rejecting workouts with multiple sections of the same type (e.g., two accessory blocks). Dropped the constraint via migration `00022`. Added prompt guidance allowing multiple same-type sections when appropriate.
+- **Generation speed plan evaluated**: Reviewed all 5 steps of the speed plan. Steps 1 (parallelize queries), 4 (defer save), and 5 (progressive stages) deprioritized as marginal or risky. Step 2 (prompt caching) noted as low-effort future win. Step 3 partially executed (coaching cues only, kept regression). Plan updated with rationale.
+- **Backlog updated**: Added low-priority item for re-enabling coaching cues with restore instructions.
+- **Migration pushed to production**: `00022_drop_unique_section_type.sql` applied to hosted Supabase via `supabase db push`.
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Remove coaching cues, keep regression | Cues are generic fitness knowledge (high token cost, low value). Regression is actionable for users ("Easier: goblet squat"). |
+| Drop DB constraint, don't tighten prompt | Multiple same-type sections are legitimate (two accessory blocks). Prompt already guides section composition via goal templates. |
+| Deprioritize other speed plan steps | DB queries are ~200ms total (marginal). Deferred save risks silent data loss. Progressive stages would be fake (no intermediate signal from edge function). |
+| Soft prompt guardrail instead of hard constraint | "Don't duplicate warmup or cooldown" in prompt vs DB enforcement. Allows flexibility while preventing obvious problems. |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `supabase/functions/generate-workout/prompt.ts` | Modified — removed coaching_cues from output schema, added multi-section guidance |
+| `supabase/functions/generate-section/index.ts` | Modified — removed coaching_cues from output schema |
+| `src/lib/workout-api.ts` | Modified — nulled coaching_cues in transform and DB save |
+| `src/hooks/useExerciseSwap.ts` | Modified — empty array for coaching_cues mapping |
+| `supabase/migrations/00022_drop_unique_section_type.sql` | Created — drops unique section type constraint |
+| `docs/BACKLOG.md` | Modified — added re-enable coaching cues item |
+| `~/.claude/plans/lexical-scribbling-lamport.md` | Modified — Step 3 marked partially done, other steps deprioritized |
+
+#### Status
+- Build passes, types clean
+- Migration applied locally and to production
+- Changes uncommitted on main — needs commit + PR
+
+---
 
 ### Session: 2026-03-05 - Exercise Swap, Scan Loader System, and UI Polish
 

--- a/src/components/workout/ActiveExerciseCard.tsx
+++ b/src/components/workout/ActiveExerciseCard.tsx
@@ -101,8 +101,8 @@ export const ActiveExerciseCard = ({
             >
                 <div className="flex-1 min-w-0 space-y-1">
                     <div className="flex items-center justify-between gap-2">
-                        <h3
-                            className="text-heading-h6 font-bold leading-tight uppercase"
+                        <h4
+                            className="text-label-md font-bold leading-tight uppercase"
                             style={{ color: isEmomInactive ? 'var(--text-disabled)' : 'var(--text-card-header)' }}
                         >
                             {pairLabel && (
@@ -114,7 +114,7 @@ export const ActiveExerciseCard = ({
                                 </span>
                             )}
                             {exercise.name}
-                        </h3>
+                        </h4>
                         {minuteLabel && (
                             <span
                                 className="text-label-xs uppercase tracking-wider shrink-0"

--- a/src/hooks/useExerciseSwap.ts
+++ b/src/hooks/useExerciseSwap.ts
@@ -133,7 +133,7 @@ export function useExerciseSwap(
       effort_percent: exercise.effort ? parseInt(exercise.effort) || null : null,
       tempo: exercise.tempo || null,
       rest_seconds: exercise.rest ? parseInt(exercise.rest) || null : null,
-      coaching_cues: exercise.coachingCues || [],
+      coaching_cues: [],
       regression: exercise.regression || null,
       structure: apiStructure,
     };

--- a/src/lib/workout-api.ts
+++ b/src/lib/workout-api.ts
@@ -47,7 +47,7 @@ export function transformAPIWorkoutToFrontend(
       effort: ex.effort_percent ? `${ex.effort_percent}%` : undefined,
       tempo: ex.tempo || undefined,
       rest: ex.rest_seconds ? `${ex.rest_seconds}s` : undefined,
-      coachingCues: ex.coaching_cues || undefined,
+      coachingCues: undefined,
       regression: ex.regression || undefined,
       equipment: ex.equipment || undefined,
       structure: ex.structure
@@ -258,7 +258,7 @@ export async function saveGeneratedWorkout(
         effort_percent: exercise.effort_percent || null,
         tempo: exercise.tempo || null,
         rest_seconds: exercise.rest_seconds || null,
-        coaching_cues: exercise.coaching_cues?.join('\n') || null,
+        coaching_cues: null,
         order_index: exerciseIndex,
       })),
     }));

--- a/supabase/functions/generate-section/index.ts
+++ b/supabase/functions/generate-section/index.ts
@@ -108,7 +108,6 @@ OUTPUT FORMAT:
       "effort_percent": number|null,
       "tempo": "string|null",
       "rest_seconds": number|null,
-      "coaching_cues": ["array"],
       "regression": "string|null",
       "structure": { "type": "standard|superset|circuit|emom|amrap|for_time|timed", "group_id": "string (required for non-standard)", ...params }
     }

--- a/supabase/functions/generate-workout/prompt.ts
+++ b/supabase/functions/generate-workout/prompt.ts
@@ -297,8 +297,9 @@ When time is tight (under 30 min):
 - For balanced goal under 30 min: Drop conditioning entirely. You can't do everything in 25 minutes.
 
 When time is generous (over 60 min):
-- Add volume (more sets, more accessory exercises), NOT more sections
+- Add volume (more sets, more accessory exercises), or split into multiple sections of the same type (e.g., two accessory blocks)
 - Don't pad with filler. If the goal is Strength and you have 75 minutes, do more sets of the primary and more accessory work. Don't add a random AMRAP.
+- You CAN use multiple sections of the same type when it makes sense (e.g., upper accessories + lower accessories). Don't duplicate warmup or cooldown.
 
 ---
 
@@ -374,7 +375,6 @@ Return valid JSON matching this exact schema. No markdown, no explanation — ju
           "effort_percent": number|null,
           "tempo": "string|null - e.g. '3-1-2'",
           "rest_seconds": number|null,
-          "coaching_cues": ["array of coaching cue strings"],
           "regression": "string|null - easier alternative",
           "structure": { "type": "standard|superset|circuit|emom|amrap|for_time|timed", "group_id": "string (required for all non-standard types, same for exercises in the same group)", ...params }
         }

--- a/supabase/migrations/00022_drop_unique_section_type.sql
+++ b/supabase/migrations/00022_drop_unique_section_type.sql
@@ -1,0 +1,5 @@
+-- Migration: Drop unique constraint on (session_id, section_type)
+-- A workout can legitimately have multiple sections of the same type
+-- (e.g., two accessory blocks). The prompt guides Claude on section balance.
+
+DROP INDEX IF EXISTS idx_workout_sections_unique_type;


### PR DESCRIPTION
## Summary
- **Drop coaching_cues from AI output schema** in both `generate-workout` and `generate-section` prompts — reduces output tokens by ~300-750 per workout, directly cutting generation time. Regression kept. Re-enabling is a one-line restore per prompt file.
- **Fix workout save failure** — `idx_workout_sections_unique_type` constraint rejected workouts with multiple sections of the same type. Dropped via migration `00022`. Added soft prompt guidance for multi-section usage.
- **Reduce workout card title size** — `ActiveExerciseCard` title from h3/h6 (20px) to h4/label-md (16px) to match review cards.
- **Backlog items added** — 1RM testing mode, progressive loading for strength workouts.
- **Migration already applied to production** via `supabase db push`.

## Test plan
- [ ] Generate a workout end-to-end — confirm it saves without duplicate key error
- [ ] Verify generated exercises have no coaching_cues in API response
- [ ] Verify ExerciseCard renders cleanly (no cues, no errors)
- [ ] Exercise swap still works
- [ ] Workout card title size matches review card title size
- [ ] `npx tsc --noEmit` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)