### PR TITLE
Replace anchor grid with coverage-based auto-recommendation

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-04-23 (17th session)
+**Last Session:** 2026-04-23 (18th session)
 
 ---
 
@@ -13,14 +13,63 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** Design System Documentation (complete)
-**Current Task:** All design system self-training infrastructure in place
-**Last Completed:** LLM-reproducible design system docs, passive drift detection, aesthetic calibration system
-**Blocking Issues:** Production Supabase dashboard needs reset-password redirect URL added
+**Current Phase:** Generation Screen Overhaul
+**Current Task:** Auto-anchor recommendation based on muscle group coverage
+**Last Completed:** Generation screen simplified — anchor grid removed, coverage-based RPC added, prompt updated for notes override
+**Blocking Issues:** Production Supabase dashboard needs reset-password redirect URL added; migration 00027 needs `supabase db reset` or `migration up` locally
 
 ---
 
 ## Session Entries
+
+### Session: 2026-04-23 - Generation Screen Overhaul: Auto-Anchor + Simplification
+
+**Duration:** ~1 hour
+**Mode:** Claude Code
+**Branch:** `feature/generation-screen-overhaul`
+
+#### What Got Done
+- **Coverage-based anchor RPC** (`00027_suggest_anchor_rpc.sql`): Supabase RPC that queries last 7 days of completed sessions, joins through workout_sections → exercises → exercise_muscle_groups, groups by body region (lower/upper push/upper pull/core), scores by staleness + underwork, returns suggested anchor with reason
+- **useSuggestedAnchor hook**: Calls RPC on mount, caches result, falls back to local `getSuggestedAnchor()` heuristic if RPC fails
+- **GenerationScreen simplified**: Removed interactive AnchorGrid and goal badge. Added read-only "Recommended Focus" card showing system-suggested anchor with reason text
+- **Textarea white background bug fixed**: Added `background: transparent` to form element CSS reset
+- **Prompt updated**: Added principle #8 making notes-based anchor override explicit (e.g., "upper body today" overrides auto-selection)
+- **Type narrowed**: `WorkoutParams.anchor` changed from `AnchorType | null` to `AnchorType`
+- **Import cleanup**: `anchor-mapping.ts` redirected from `AnchorGrid` to `@/types/workout`
+- **Goal badge CSS removed**: Dead styles cleaned up from index.css
+- **Code review fixes**: Generate button disabled while anchor loads; removed stale `workoutHistory` from hook dependency array
+
+#### What Came Up (Unexpected)
+- Two concurrent sessions (tailwind removal close-out + this work) competed over file state. Tailwind removal PR (#30) was already merged to main by the other session, making `feature/tailwind-removal` stale. Had to create a fresh branch off main and re-apply all changes.
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| RPC over simple recency heuristic | Session-level anchors can't distinguish muscle coverage — RPC operates on actual exercise muscle groups for smarter recommendations |
+| Read-only card, not interactive | System recommends; notes override. No need for user to manually pick anchor when coverage data is available |
+| Keep AnchorGrid component in codebase | Still used by ComponentGallery — don't delete, just stop importing in GenerationScreen |
+| `SECURITY DEFINER` on RPC | Needs to query across tables with RLS; function runs with creator's permissions |
+| Fallback to local heuristic on RPC failure | Graceful degradation — new users or offline still get a reasonable suggestion |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `src/index.css` | Modified — `background: transparent` in form reset; removed goal-badge CSS |
+| `src/pages/GenerationScreen.tsx` | Modified — removed AnchorGrid/goal badge, added recommended focus card |
+| `src/hooks/useSuggestedAnchor.ts` | Created — hook for coverage-based anchor suggestion |
+| `supabase/migrations/00027_suggest_anchor_rpc.sql` | Created — RPC for muscle group coverage analysis |
+| `src/types/workout.ts` | Modified — narrowed `WorkoutParams.anchor` to non-nullable |
+| `src/components/OptionalFields.tsx` | Modified — updated notes placeholder |
+| `src/lib/anchor-mapping.ts` | Modified — redirected type import to `@/types/workout` |
+| `supabase/functions/generate-workout/prompt.ts` | Modified — added notes-override principle |
+
+#### Status
+- Build passes, typecheck passes
+- 1 commit on `feature/generation-screen-overhaul`
+- Not yet pushed or PR'd
+- Migration `00027` needs to be applied locally
+
+---
 
 ### Session: 2026-04-23 - LLM-Reproducible Design System & Self-Training Infrastructure
 

--- a/src/components/OptionalFields.tsx
+++ b/src/components/OptionalFields.tsx
@@ -104,7 +104,7 @@ function NotesField({ value, onChange }: NotesFieldProps) {
       <Textarea
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Any notes or modifications..."
+        placeholder="Override focus area, request modifications, flag injuries..."
         style={{ minHeight: '85px' }}
       />
     </Card>

--- a/src/hooks/useSuggestedAnchor.ts
+++ b/src/hooks/useSuggestedAnchor.ts
@@ -33,6 +33,9 @@ export function useSuggestedAnchor(): SuggestedAnchorResult {
         if (error) throw error;
 
         const result = typeof data === 'string' ? JSON.parse(data) : data;
+        if (!result?.suggested_anchor || !result?.reason) {
+          throw new Error('Invalid RPC response shape');
+        }
         setSuggestedAnchor(result.suggested_anchor as AnchorType);
         setReason(result.reason);
       } catch (err) {

--- a/src/hooks/useSuggestedAnchor.ts
+++ b/src/hooks/useSuggestedAnchor.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useRef } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuthContext } from '@/contexts/AuthContext';
+import type { AnchorType } from '@/types/workout';
+import { getSuggestedAnchor } from '@/types/workout';
+import { useHomeDataContext } from '@/contexts/HomeDataContext';
+import { logger } from '@/lib/logger';
+
+interface SuggestedAnchorResult {
+  suggestedAnchor: AnchorType;
+  reason: string;
+  isLoading: boolean;
+}
+
+export function useSuggestedAnchor(): SuggestedAnchorResult {
+  const { user } = useAuthContext();
+  const { workoutHistory } = useHomeDataContext();
+  const [suggestedAnchor, setSuggestedAnchor] = useState<AnchorType>('FULL BODY');
+  const [reason, setReason] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const fetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (fetchedRef.current || !user?.id) return;
+    fetchedRef.current = true;
+
+    async function fetchSuggestion() {
+      try {
+        const { data, error } = await supabase.rpc('suggest_anchor', {
+          p_user_id: user!.id,
+        });
+
+        if (error) throw error;
+
+        const result = typeof data === 'string' ? JSON.parse(data) : data;
+        setSuggestedAnchor(result.suggested_anchor as AnchorType);
+        setReason(result.reason);
+      } catch (err) {
+        logger.workout.warn('suggest_anchor RPC failed, falling back to local', { err });
+        // Fallback to local heuristic
+        const fallback = getSuggestedAnchor(workoutHistory);
+        setSuggestedAnchor(fallback);
+        setReason('Based on recent workout history');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchSuggestion();
+  }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps — workoutHistory is only needed for fallback, fetchedRef prevents re-runs
+
+  return { suggestedAnchor, reason, isLoading };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,7 @@ button, input, textarea, select {
   font-weight: inherit;
   line-height: inherit;
   color: inherit;
+  background: transparent;
   margin: 0;
   padding: 0;
 }
@@ -1421,36 +1422,6 @@ body {
     font-weight: var(--font-weight-bold);
   }
 
-  /* Goal badge — read-only display on generation screen */
-  .goal-badge {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-    padding: var(--space-3) var(--space-4);
-    background: var(--surface-sunken);
-    border: 1px solid var(--border-default);
-  }
-  .goal-badge__label {
-    font-family: var(--font-label);
-    font-size: var(--text-xs);
-    font-weight: var(--font-weight-bold);
-    letter-spacing: var(--tracking-widest);
-    text-transform: uppercase;
-    color: var(--text-muted);
-  }
-  .goal-badge__value {
-    font-family: var(--font-heading);
-    font-size: var(--text-lg);
-    font-weight: var(--font-weight-bold);
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-wide);
-    color: var(--text-primary);
-  }
-  .goal-badge__hint {
-    font-family: var(--font-paragraph);
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-  }
 
 /* CTAButton hover state overrides */
 .cta-btn-primary:hover {

--- a/src/lib/anchor-mapping.ts
+++ b/src/lib/anchor-mapping.ts
@@ -13,7 +13,7 @@
  * Avoidance: Tries not to repeat the most recent anchor in a category.
  */
 
-import type { AnchorType, MovementPattern } from "@/components/AnchorGrid";
+import type { AnchorType, MovementPattern } from "@/types/workout";
 
 // Category mappings
 const LOWER_PATTERNS: MovementPattern[] = ["squat", "hinge"];

--- a/src/pages/GenerationScreen.tsx
+++ b/src/pages/GenerationScreen.tsx
@@ -3,19 +3,21 @@ import { useNavigate } from "react-router-dom";
 import { PageHeader } from "@/components/PageHeader";
 import { AppLayout } from "@/layouts";
 import { IntensitySlider } from "@/components/IntensitySlider";
-import { AnchorGrid, AnchorType } from "@/components/AnchorGrid";
 import { LocationAccordion } from "@/components/LocationAccordion";
 import { OptionalFields } from "@/components/OptionalFields";
 import { GenerateButton } from "@/components/GenerateButton";
 import { FullscreenLoader } from "@/components/ScanLoader";
+import { Card } from "@/components/Card";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useWorkoutFlowContext } from "@/contexts/WorkoutFlowContext";
-import { GOAL_PRESETS, INTENSITY_RANGE_BY_GOAL } from "@/types/workout";
+import { useSuggestedAnchor } from "@/hooks/useSuggestedAnchor";
+import { INTENSITY_RANGE_BY_GOAL } from "@/types/workout";
 
 export const GenerationScreen = () => {
   const navigate = useNavigate();
   const { profile, locations } = useAuthContext();
   const { handleGenerate: generateWorkout, isGenerating, cancelGeneration } = useWorkoutFlowContext();
+  const { suggestedAnchor, reason, isLoading: anchorLoading } = useSuggestedAnchor();
 
   const defaultLocation = locations.find(
     l => l.id === profile?.defaultLocationId
@@ -23,11 +25,9 @@ export const GenerationScreen = () => {
 
   // Goal comes from profile (set in Settings), not per-workout
   const goal = profile?.goal || 'balanced';
-  const goalPreset = GOAL_PRESETS.find(g => g.value === goal);
   const intensityRange = INTENSITY_RANGE_BY_GOAL[goal];
 
   const [intensity, setIntensity] = useState(intensityRange.default);
-  const [anchor, setAnchor] = useState<AnchorType | null>(null);
   const [location, setLocation] = useState(defaultLocation?.name || "Gym");
   const [time, setTime] = useState("45");
   const [notes, setNotes] = useState("");
@@ -35,14 +35,14 @@ export const GenerationScreen = () => {
   const handleGenerate = () => {
     generateWorkout({
       intensity,
-      anchor,
+      anchor: suggestedAnchor,
       location,
       time,
       notes,
     }, () => navigate("/review"));
   };
 
-  const canGenerate = anchor !== null && time !== "";
+  const canGenerate = time !== "" && !anchorLoading;
 
   return (
     <>
@@ -52,17 +52,31 @@ export const GenerationScreen = () => {
       footer={<GenerateButton onClick={handleGenerate} disabled={!canGenerate} isLoading={isGenerating} />}
     >
       <div className="stagger-reveal" style={{ paddingTop: 'var(--spacing-600)', display: 'flex', flexDirection: 'column', gap: 'var(--spacing-600)' }}>
-        <div className="goal-badge">
-          <span className="goal-badge__label">TRAINING GOAL</span>
-          <span className="goal-badge__value">{goalPreset?.label || 'Balanced'}</span>
-          <span className="goal-badge__hint">{goalPreset?.description}</span>
-        </div>
-
-        <AnchorGrid
-          selected={anchor}
-          onSelect={setAnchor}
-          disablePower={goal === 'active_recovery'}
-        />
+        <Card cornerSize="md" padding="md">
+          <span
+            className="text-label-xs"
+            style={{ color: 'var(--text-card-label)', textTransform: 'uppercase', letterSpacing: '0.1em', display: 'block', marginBottom: 'var(--spacing-200)' }}
+          >
+            Recommended Focus
+          </span>
+          {anchorLoading ? (
+            <span className="text-paragraph-sm" style={{ color: 'var(--text-muted)' }}>Analyzing coverage...</span>
+          ) : (
+            <>
+              <span
+                className="text-heading-h4"
+                style={{ color: 'var(--text-primary)', display: 'block', marginBottom: 'var(--spacing-100)' }}
+              >
+                {suggestedAnchor}
+              </span>
+              {reason && (
+                <span className="text-paragraph-sm" style={{ color: 'var(--text-muted)' }}>
+                  {reason}
+                </span>
+              )}
+            </>
+          )}
+        </Card>
 
         <IntensitySlider
           value={intensity}

--- a/src/pages/GenerationScreen.tsx
+++ b/src/pages/GenerationScreen.tsx
@@ -65,7 +65,7 @@ export const GenerationScreen = () => {
             <>
               <span
                 className="text-heading-h4"
-                style={{ color: 'var(--text-primary)', display: 'block', marginBottom: 'var(--spacing-100)' }}
+                style={{ color: 'var(--text-header)', display: 'block', marginBottom: 'var(--spacing-100)' }}
               >
                 {suggestedAnchor}
               </span>

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -208,7 +208,7 @@ export interface GeneratedWorkout {
 // Goal is read from user profile, not selected per-workout
 export interface WorkoutParams {
   intensity: number;
-  anchor: AnchorType | null;
+  anchor: AnchorType;
   location: string;
   time: string;
   notes: string;

--- a/supabase/functions/generate-workout/prompt.ts
+++ b/supabase/functions/generate-workout/prompt.ts
@@ -36,6 +36,7 @@ CORE PRINCIPLES:
 5. Keep workouts within the requested duration — cut lower-priority sections first if needed
 6. Use workout history to balance movement patterns across sessions
 7. User safety > User notes > Goal template > Intensity scaling > Variety
+8. The anchor/movement pattern is auto-selected by the system based on weekly muscle group coverage. If the user's notes specify a body part, muscle group, or movement preference (e.g., "upper body today", "I want to deadlift", "skip legs"), honor that over the auto-selected anchor.
 
 ---
 

--- a/supabase/migrations/00027_suggest_anchor_rpc.sql
+++ b/supabase/migrations/00027_suggest_anchor_rpc.sql
@@ -1,0 +1,124 @@
+-- RPC: suggest_anchor
+-- Returns a recommended focus area based on muscle group coverage from the last 7 days.
+-- Groups muscle groups by body region, scores by staleness and underwork,
+-- and maps the most underworked region to an AnchorType.
+
+CREATE OR REPLACE FUNCTION suggest_anchor(p_user_id UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  result JSON;
+BEGIN
+  WITH recent_sessions AS (
+    SELECT ws.id AS session_id, ws.date
+    FROM workout_sessions ws
+    WHERE ws.user_id = p_user_id
+      AND ws.status = 'completed'
+      AND ws.date >= (CURRENT_DATE - INTERVAL '7 days')
+  ),
+  exercise_muscles AS (
+    SELECT
+      emg.muscle_group,
+      emg.role,
+      rs.date
+    FROM recent_sessions rs
+    JOIN workout_sections wsec ON wsec.session_id = rs.session_id
+    JOIN exercises ex ON ex.section_id = wsec.id
+    JOIN exercise_muscle_groups emg ON emg.exercise_id = ex.id
+  ),
+  region_mapping AS (
+    SELECT
+      muscle_group,
+      role,
+      date,
+      CASE
+        WHEN muscle_group IN ('quads', 'hamstrings', 'glutes', 'calves', 'hip_flexors') THEN 'lower'
+        WHEN muscle_group IN ('pecs', 'front_delts', 'side_delts', 'triceps') THEN 'upper_push'
+        WHEN muscle_group IN ('lats', 'rhomboids', 'rear_delts', 'biceps', 'traps') THEN 'upper_pull'
+        WHEN muscle_group IN ('abs', 'obliques', 'erectors') THEN 'core'
+        ELSE 'other'
+      END AS region
+    FROM exercise_muscles
+  ),
+  region_scores AS (
+    SELECT
+      region,
+      COUNT(*) FILTER (WHERE role = 'primary') AS primary_hits,
+      COUNT(*) FILTER (WHERE role = 'synergist') AS synergist_hits,
+      MAX(date) AS last_hit,
+      EXTRACT(DAY FROM (CURRENT_DATE - MAX(date))) AS days_since
+    FROM region_mapping
+    WHERE region != 'other'
+    GROUP BY region
+  ),
+  -- Include regions with zero hits
+  all_regions AS (
+    SELECT region FROM (VALUES ('lower'), ('upper_push'), ('upper_pull'), ('core')) AS r(region)
+  ),
+  scored AS (
+    SELECT
+      ar.region,
+      COALESCE(rs.primary_hits, 0) AS primary_hits,
+      COALESCE(rs.synergist_hits, 0) AS synergist_hits,
+      rs.last_hit,
+      COALESCE(rs.days_since, 8) AS days_since, -- never hit = 8 days (max staleness)
+      -- Score: higher = more underworked. Weight staleness heavily.
+      (COALESCE(rs.days_since, 8) * 10) - (COALESCE(rs.primary_hits, 0) * 3) AS score
+    FROM all_regions ar
+    LEFT JOIN region_scores rs ON rs.region = ar.region
+  ),
+  best AS (
+    SELECT * FROM scored ORDER BY score DESC LIMIT 1
+  )
+  SELECT json_build_object(
+    'suggested_anchor',
+    CASE best.region
+      WHEN 'lower' THEN 'LOWER BODY'
+      WHEN 'upper_push' THEN 'UPPER BODY'
+      WHEN 'upper_pull' THEN 'UPPER BODY'
+      WHEN 'core' THEN 'FULL BODY'
+      ELSE 'FULL BODY'
+    END,
+    'reason',
+    CASE
+      WHEN best.days_since >= 8 OR best.last_hit IS NULL THEN
+        CASE best.region
+          WHEN 'lower' THEN 'Lower body — not trained this week'
+          WHEN 'upper_push' THEN 'Upper body (push) — not trained this week'
+          WHEN 'upper_pull' THEN 'Upper body (pull) — not trained this week'
+          WHEN 'core' THEN 'Core — not trained this week'
+          ELSE 'Full body — no recent data'
+        END
+      ELSE
+        CASE best.region
+          WHEN 'lower' THEN 'Lower body — last trained ' || best.days_since || ' days ago'
+          WHEN 'upper_push' THEN 'Upper body (push) — last trained ' || best.days_since || ' days ago'
+          WHEN 'upper_pull' THEN 'Upper body (pull) — last trained ' || best.days_since || ' days ago'
+          WHEN 'core' THEN 'Core — last trained ' || best.days_since || ' days ago'
+          ELSE 'Full body — last trained ' || best.days_since || ' days ago'
+        END
+    END,
+    'coverage',
+    (SELECT json_agg(json_build_object(
+      'region', s.region,
+      'primary_hits', s.primary_hits,
+      'synergist_hits', s.synergist_hits,
+      'days_since', s.days_since
+    )) FROM scored s)
+  ) INTO result
+  FROM best;
+
+  -- If no data at all (new user, no sessions), return FULL BODY default
+  IF result IS NULL THEN
+    result := json_build_object(
+      'suggested_anchor', 'FULL BODY',
+      'reason', 'No recent workout data — starting with full body',
+      'coverage', '[]'::json
+    );
+  END IF;
+
+  RETURN result;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Remove interactive AnchorGrid and goal badge from generation screen
- Add coverage-based anchor suggestion via Supabase RPC (`suggest_anchor`)
- Show read-only "Recommended Focus" card with system recommendation
- Fix textarea white background bug (CSS reset)
- Update prompt to honor notes-based anchor overrides

## Test plan
- [ ] Apply migration: `npx supabase db reset` or `npx supabase migration up`
- [ ] Generation screen shows recommended focus (read-only), no anchor grid or goal badge
- [ ] Textarea has dark background (not white)
- [ ] Generate a workout — system-selected anchor appears on review screen
- [ ] Generate with notes like "upper body today" — verify override works
- [ ] Onboarding flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)