### PR TITLE
Add per-set exercise logging with last-session pre-fill

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -95,11 +95,11 @@ Important but not blocking. Address after core features complete.
 ### Low Priority
 Nice to have. Address when time permits or for future versions.
 
-- [ ] **Re-enable coaching cues in generation** - Add `coaching_cues` back to output schema in prompt files
+- [x] **Re-enable coaching cues in generation** - Add `coaching_cues` back to output schema in prompt files
   - Priority: Low
   - Type: Enhancement
   - Added: 2026-03-05
-  - Context: Removed from `generate-workout/prompt.ts` and `generate-section/index.ts` output schemas to reduce output tokens and speed up generation. Regression was kept. To restore: add `"coaching_cues": ["array of coaching cue strings"],` back to each prompt's output schema. Frontend (`ExerciseCard.tsx`) already renders them conditionally — no UI changes needed. DB column still exists.
+  - Completed: 2026-04-23 — Superseded by GitHub Issue #37 (client-side DB enrichment approach)
 
 - [ ] **Dev-only gate for devtools** - Hide ComponentGallery and other dev tools behind `import.meta.env.DEV` so they're excluded from production builds
   - Priority: Low
@@ -170,11 +170,11 @@ New functionality to build.
   - Added: 2026-03-05
   - Context: Separate goal/mode for maximal strength testing. Would need warmup ramp-up sets, attempt tracking, rest period guidance (3-5 min), and history to track PR progression over time.
 
-- [ ] **Progressive loading for strength workouts** - Add a progressive load section to strength-focused workouts
+- [x] **Progressive loading for strength workouts** - Add a progressive load section to strength-focused workouts
   - Priority: Low
   - Type: Feature
   - Added: 2026-03-05
-  - Context: Strength training benefits from structured warm-up/ramp-up sets building toward working weight. Could be a new section type or integrated into primary_lift section with ascending load percentages (e.g., bar only → 50% → 70% → 85% → working sets).
+  - Completed: 2026-04-23 — Superseded by GitHub Issue #36 (Progressive Overload Engine)
 
 - [ ]
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-04-23 (18th session)
+**Last Session:** 2026-04-23 (19th session)
 
 ---
 
@@ -13,14 +13,46 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** Generation Screen Overhaul
-**Current Task:** Auto-anchor recommendation based on muscle group coverage
-**Last Completed:** Generation screen simplified — anchor grid removed, coverage-based RPC added, prompt updated for notes override
-**Blocking Issues:** Production Supabase dashboard needs reset-password redirect URL added; migration 00027 needs `supabase db reset` or `migration up` locally
+**Current Phase:** Smart Training System planning
+**Current Task:** Ticket suite created, ready to begin Phase 1 (Set-by-Set Logging + Coaching Cues)
+**Last Completed:** 8-ticket PRD suite created as GitHub Issues (#34–#41), superseded issues closed with context preserved
+**Blocking Issues:** Production Supabase dashboard needs reset-password redirect URL added; 37 token-lint violations pending
 
 ---
 
 ## Session Entries
+
+### Session: 2026-04-23 - Smart Training System: PRD Ticket Suite
+
+**Duration:** ~30 min
+**Mode:** Claude Code
+**Branch:** `main` (planning only — no code changes)
+
+#### What Got Done
+- **8 GitHub Issues created (#34–#41):** Full PRD ticket suite for the Smart Training System — set-by-set logging, rest timer, progressive overload, coaching cues, smart intensity, workout insights, offline-first, and adaptive learning loop
+- **Cross-referenced existing issues:** #18 (circuit auto-progress), #24 (section notes), #26 (1RM testing) linked as related work
+- **Closed superseded issues:** #20 (coaching cues via LLM) → superseded by #37 (client-side DB enrichment); #27 (progressive loading) → superseded by #36 (overload engine). All original context preserved in closing comments and new ticket bodies
+- **New labels created:** `area:data`, `area:generation`, `status:blocked`
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Close #20 and #27 as superseded | New tickets (#37, #36) fully encompass the original scope with better approaches — no context lost |
+| Keep #26 (1RM testing) open | Distinct feature that extends #36's PR system but isn't replaced by it |
+| Keep #18 and #24 open | Related but independent UX improvements, not encompassed by new tickets |
+| Client-side cue enrichment over LLM re-enable | Avoids the token cost that caused original removal — better approach |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| No code files changed | Planning-only session |
+
+#### Status
+- No commits — planning session
+- 8 issues ready on GitHub board
+- Next: start Phase 1 — pull #34 (Set-by-Set Logging) or #37 (Coaching Cues)
+
+---
 
 ### Session: 2026-04-23 - Generation Screen Overhaul: Auto-Anchor + Simplification
 

--- a/src/components/workout/ActiveExerciseCard.test.tsx
+++ b/src/components/workout/ActiveExerciseCard.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import type { Exercise, SetLog } from '@/types/workout';
+
+// Extract the pure logic from ActiveExerciseCard for testing.
+// These mirror the inline functions in the component.
+
+const WEIGHTED_EQUIPMENT = ['barbell', 'dumbbell', 'dumbbells', 'kettlebell', 'cable', 'machine', 'ez bar', 'trap bar', 'smith machine', 'plate'];
+
+function detectPerSetInputs(exercise: Exercise, onSetLog: boolean): boolean {
+  const showInputs = true; // assume non-warmup
+  const hasWeight = !!(exercise.equipment && WEIGHTED_EQUIPMENT.includes(exercise.equipment.toLowerCase()));
+  const isNumericReps = /^\d+$/.test(exercise.reps);
+  const hasStandardSets = exercise.sets != null && exercise.sets > 0;
+  const isTimedStructure = ['emom', 'amrap', 'for_time'].includes(exercise.structure?.type || '');
+  const isCircuit = exercise.structure?.type === 'circuit';
+  return showInputs && isNumericReps && hasStandardSets && !isTimedStructure && !isCircuit && onSetLog;
+}
+
+function buildInitialSets(exercise: Exercise, hasWeight: boolean): SetLog[] {
+  const numSets = exercise.sets || 1;
+  const prescribedReps = parseInt(exercise.reps);
+  const defaultReps = isNaN(prescribedReps) ? undefined : prescribedReps;
+  return Array.from({ length: numSets }, (_, i) => {
+    const lastSet = exercise.lastSetData?.[i];
+    return {
+      setNumber: i + 1,
+      weight: lastSet?.weight ?? undefined,
+      weightUnit: lastSet?.weightUnit || 'lbs',
+      reps: lastSet?.reps ?? defaultReps,
+    };
+  });
+}
+
+function summarizeSets(sets: SetLog[], hasWeight: boolean): string {
+  if (sets.length === 0) return '';
+  const parts = sets
+    .filter(s => (hasWeight ? s.weight != null : s.reps != null))
+    .map(s => {
+      if (hasWeight && s.weight != null && s.reps != null) return `${s.weight}×${s.reps}`;
+      if (hasWeight && s.weight != null) return `${s.weight}`;
+      if (s.reps != null) return `${s.reps}`;
+      return '';
+    })
+    .filter(Boolean);
+  if (parts.length > 1 && parts.every(p => p === parts[0])) {
+    return `${parts[0]} (${parts.length} sets)`;
+  }
+  return parts.join(', ');
+}
+
+const baseExercise: Exercise = {
+  id: 'ex1',
+  name: 'Back Squat',
+  sets: 4,
+  reps: '8',
+  equipment: 'barbell',
+  structure: { type: 'standard' },
+};
+
+describe('Per-set detection heuristic', () => {
+  it('enables per-set for standard barbell exercise with numeric reps', () => {
+    expect(detectPerSetInputs(baseExercise, true)).toBe(true);
+  });
+
+  it('disables per-set when onSetLog is not provided', () => {
+    expect(detectPerSetInputs(baseExercise, false)).toBe(false);
+  });
+
+  it('disables per-set for non-numeric reps ("30 sec")', () => {
+    expect(detectPerSetInputs({ ...baseExercise, reps: '30 sec' }, true)).toBe(false);
+  });
+
+  it('disables per-set for "10 each" reps', () => {
+    expect(detectPerSetInputs({ ...baseExercise, reps: '10 each' }, true)).toBe(false);
+  });
+
+  it('disables per-set for AMRAP exercises', () => {
+    expect(detectPerSetInputs({
+      ...baseExercise,
+      structure: { type: 'amrap', minutes: 10, group_id: 'g1' },
+    }, true)).toBe(false);
+  });
+
+  it('disables per-set for EMOM exercises', () => {
+    expect(detectPerSetInputs({
+      ...baseExercise,
+      structure: { type: 'emom', minutes: 10, group_id: 'g1' },
+    }, true)).toBe(false);
+  });
+
+  it('disables per-set for circuit exercises', () => {
+    expect(detectPerSetInputs({
+      ...baseExercise,
+      structure: { type: 'circuit', circuit_id: 'c1', rounds: 3, group_id: 'g1' },
+    }, true)).toBe(false);
+  });
+
+  it('disables per-set for for_time exercises', () => {
+    expect(detectPerSetInputs({
+      ...baseExercise,
+      structure: { type: 'for_time', time_cap_mins: 10, group_id: 'g1' },
+    }, true)).toBe(false);
+  });
+
+  it('enables per-set for bodyweight exercises with numeric reps', () => {
+    expect(detectPerSetInputs({
+      ...baseExercise,
+      equipment: undefined, // bodyweight
+      reps: '10',
+    }, true)).toBe(true);
+  });
+
+  it('disables per-set when sets is null', () => {
+    expect(detectPerSetInputs({ ...baseExercise, sets: null }, true)).toBe(false);
+  });
+
+  it('enables per-set for superset exercises', () => {
+    expect(detectPerSetInputs({
+      ...baseExercise,
+      structure: { type: 'superset', paired_with: 'ex2', group_id: 'g1' },
+    }, true)).toBe(true);
+  });
+});
+
+describe('buildInitialSets', () => {
+  it('creates correct number of sets from exercise prescription', () => {
+    const sets = buildInitialSets(baseExercise, true);
+    expect(sets).toHaveLength(4);
+    expect(sets[0].setNumber).toBe(1);
+    expect(sets[3].setNumber).toBe(4);
+  });
+
+  it('pre-fills reps from prescription', () => {
+    const sets = buildInitialSets(baseExercise, true);
+    expect(sets[0].reps).toBe(8);
+    expect(sets[3].reps).toBe(8);
+  });
+
+  it('pre-fills from lastSetData when available', () => {
+    const exercise: Exercise = {
+      ...baseExercise,
+      lastSetData: [
+        { setNumber: 1, weight: 135, reps: 10, weightUnit: 'lbs' },
+        { setNumber: 2, weight: 155, reps: 8, weightUnit: 'lbs' },
+        { setNumber: 3, weight: 175, reps: 6, weightUnit: 'lbs' },
+        { setNumber: 4, weight: 185, reps: 4, weightUnit: 'lbs' },
+      ],
+    };
+    const sets = buildInitialSets(exercise, true);
+    expect(sets[0].weight).toBe(135);
+    expect(sets[0].reps).toBe(10);
+    expect(sets[3].weight).toBe(185);
+    expect(sets[3].reps).toBe(4);
+  });
+
+  it('falls back to prescribed reps when lastSetData is shorter', () => {
+    const exercise: Exercise = {
+      ...baseExercise,
+      lastSetData: [
+        { setNumber: 1, weight: 135, reps: 10, weightUnit: 'lbs' },
+      ],
+    };
+    const sets = buildInitialSets(exercise, true);
+    expect(sets[0].weight).toBe(135);
+    expect(sets[0].reps).toBe(10);
+    // Sets 2-4 get prescribed reps, no weight
+    expect(sets[1].weight).toBeUndefined();
+    expect(sets[1].reps).toBe(8);
+  });
+
+  it('handles non-numeric reps gracefully', () => {
+    const exercise: Exercise = { ...baseExercise, reps: 'AMRAP', sets: 2 };
+    const sets = buildInitialSets(exercise, false);
+    expect(sets).toHaveLength(2);
+    expect(sets[0].reps).toBeUndefined(); // NaN → undefined
+  });
+});
+
+describe('summarizeSets', () => {
+  it('compresses identical sets', () => {
+    const sets: SetLog[] = [
+      { setNumber: 1, weight: 135, reps: 8 },
+      { setNumber: 2, weight: 135, reps: 8 },
+      { setNumber: 3, weight: 135, reps: 8 },
+    ];
+    expect(summarizeSets(sets, true)).toBe('135×8 (3 sets)');
+  });
+
+  it('lists different sets individually', () => {
+    const sets: SetLog[] = [
+      { setNumber: 1, weight: 135, reps: 10 },
+      { setNumber: 2, weight: 155, reps: 8 },
+      { setNumber: 3, weight: 175, reps: 6 },
+    ];
+    expect(summarizeSets(sets, true)).toBe('135×10, 155×8, 175×6');
+  });
+
+  it('shows only reps for bodyweight exercises', () => {
+    const sets: SetLog[] = [
+      { setNumber: 1, reps: 10 },
+      { setNumber: 2, reps: 10 },
+      { setNumber: 3, reps: 8 },
+    ];
+    expect(summarizeSets(sets, false)).toBe('10, 10, 8');
+  });
+
+  it('compresses identical bodyweight sets', () => {
+    const sets: SetLog[] = [
+      { setNumber: 1, reps: 10 },
+      { setNumber: 2, reps: 10 },
+      { setNumber: 3, reps: 10 },
+    ];
+    expect(summarizeSets(sets, false)).toBe('10 (3 sets)');
+  });
+
+  it('returns empty string for empty sets', () => {
+    expect(summarizeSets([], true)).toBe('');
+  });
+
+  it('handles weight-only sets', () => {
+    const sets: SetLog[] = [
+      { setNumber: 1, weight: 135 },
+      { setNumber: 2, weight: 155 },
+    ];
+    expect(summarizeSets(sets, true)).toBe('135, 155');
+  });
+});

--- a/src/components/workout/ActiveExerciseCard.tsx
+++ b/src/components/workout/ActiveExerciseCard.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
-import { ChevronDown, ChevronUp } from "@/components/icons";
-import { Exercise } from "@/types/workout";
+import { useState, useEffect, useCallback } from "react";
+import { ChevronDown, ChevronUp, X, Plus } from "@/components/icons";
+import { Exercise, ExerciseSetData, SetLog } from "@/types/workout";
 import { Card } from "../Card";
 import { Input } from "../ui/input";
 import { ExerciseNotes } from "./ExerciseNotes";
@@ -8,6 +8,8 @@ import { ExerciseNotes } from "./ExerciseNotes";
 interface ActiveExerciseCardProps {
     exercise: Exercise;
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
+    /** Called with per-set data for exercises that use set-by-set logging */
+    onSetLog?: (id: string, data: ExerciseSetData) => void;
     /** Section type — hides weight/reps for warmup, cooldown, mobility */
     sectionType?: string;
     /** Render without Card wrapper (for use inside structure cards like Superset/Circuit) */
@@ -26,6 +28,7 @@ interface ActiveExerciseCardProps {
 }
 
 const HIDE_INPUTS_SECTIONS = ['warmup', 'cooldown', 'mobility'];
+const WEIGHTED_EQUIPMENT = ['barbell', 'dumbbell', 'dumbbells', 'kettlebell', 'cable', 'machine', 'ez bar', 'trap bar', 'smith machine', 'plate'];
 
 /** Check if a rest value is meaningful (non-zero, non-empty) */
 const hasRest = (rest?: string): boolean => {
@@ -40,9 +43,51 @@ const formatPrescription = (sets: number | null, reps: string): string => {
     return `${reps} reps`;
 };
 
+/** Build initial per-set state from exercise data */
+function buildInitialSets(exercise: Exercise, hasWeight: boolean): SetLog[] {
+    const numSets = exercise.sets || 1;
+    const prescribedReps = parseInt(exercise.reps);
+    const defaultReps = isNaN(prescribedReps) ? undefined : prescribedReps;
+
+    return Array.from({ length: numSets }, (_, i) => {
+        const lastSet = exercise.lastSetData?.[i];
+        return {
+            setNumber: i + 1,
+            weight: lastSet?.weight ?? undefined,
+            weightUnit: lastSet?.weightUnit || 'lbs',
+            reps: lastSet?.reps ?? defaultReps,
+        };
+    });
+}
+
+/** Generate a summary string from set logs for backward compat */
+function summarizeSets(sets: SetLog[], hasWeight: boolean): string {
+    if (sets.length === 0) return '';
+    const parts = sets
+        .filter(s => (hasWeight ? s.weight != null : s.reps != null))
+        .map(s => {
+            if (hasWeight && s.weight != null && s.reps != null) {
+                return `${s.weight}×${s.reps}`;
+            } else if (hasWeight && s.weight != null) {
+                return `${s.weight}`;
+            } else if (s.reps != null) {
+                return `${s.reps}`;
+            }
+            return '';
+        })
+        .filter(Boolean);
+
+    // If all entries are the same, compress to "135×8 ×4 sets" style
+    if (parts.length > 1 && parts.every(p => p === parts[0])) {
+        return `${parts[0]} (${parts.length} sets)`;
+    }
+    return parts.join(', ');
+}
+
 export const ActiveExerciseCard = ({
     exercise,
     onLog,
+    onSetLog,
     sectionType,
     bare = false,
     emomState,
@@ -52,26 +97,99 @@ export const ActiveExerciseCard = ({
     defaultExpanded = false,
     className
 }: ActiveExerciseCardProps) => {
+    const showInputs = !sectionType || !HIDE_INPUTS_SECTIONS.includes(sectionType);
+    const hasWeight = !!(exercise.equipment && WEIGHTED_EQUIPMENT.includes(exercise.equipment.toLowerCase()));
+
+    // Determine if this exercise gets per-set inputs
+    const isNumericReps = /^\d+$/.test(exercise.reps);
+    const hasStandardSets = exercise.sets != null && exercise.sets > 0;
+    const isTimedStructure = ['emom', 'amrap', 'for_time'].includes(exercise.structure?.type || '');
+    const isCircuit = exercise.structure?.type === 'circuit';
+    const showPerSetInputs = showInputs && isNumericReps && hasStandardSets && !isTimedStructure && !isCircuit && !!onSetLog;
+
     const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-    const [weight, setWeight] = useState(exercise.weight_logged || exercise.lastWeight || "");
-    const [reps, setReps] = useState(exercise.reps || "");
     const [note, setNote] = useState(exercise.lastNotes || "");
 
-    const showInputs = !sectionType || !HIDE_INPUTS_SECTIONS.includes(sectionType);
+    // Per-set state (only used when showPerSetInputs)
+    const [setLogs, setSetLogs] = useState<SetLog[]>(() =>
+        showPerSetInputs ? buildInitialSets(exercise, hasWeight) : []
+    );
 
-    // Log pre-filled values on mount so they persist even if user doesn't edit
+    // Single-input state (legacy, used when !showPerSetInputs)
+    const [weight, setWeight] = useState(exercise.weight_logged || exercise.lastWeight || "");
+    const [reps, setReps] = useState(exercise.reps || "");
+
+    // Emit per-set data on mount if we have pre-fill data
     useEffect(() => {
-        const prefilled: { weight?: string; notes?: string } = {};
-        if (exercise.lastWeight) prefilled.weight = exercise.lastWeight;
-        if (exercise.lastNotes) prefilled.notes = exercise.lastNotes;
-        if (Object.keys(prefilled).length > 0) {
-            onLog(exercise.id, prefilled);
+        if (showPerSetInputs && setLogs.length > 0) {
+            const summary = summarizeSets(setLogs, hasWeight);
+            onSetLog(exercise.id, { sets: setLogs, notes: note || undefined });
+            if (summary) {
+                onLog(exercise.id, { weight: summary });
+            }
+        } else {
+            // Legacy pre-fill
+            const prefilled: { weight?: string; notes?: string } = {};
+            if (exercise.lastWeight) prefilled.weight = exercise.lastWeight;
+            if (exercise.lastNotes) prefilled.notes = exercise.lastNotes;
+            if (Object.keys(prefilled).length > 0) {
+                onLog(exercise.id, prefilled);
+            }
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-    const WEIGHTED_EQUIPMENT = ['barbell', 'dumbbell', 'dumbbells', 'kettlebell', 'cable', 'machine', 'ez bar', 'trap bar', 'smith machine', 'plate'];
-    const hasWeight = exercise.equipment && WEIGHTED_EQUIPMENT.includes(exercise.equipment.toLowerCase());
 
+    const emitSetLog = useCallback((updatedSets: SetLog[], updatedNote?: string) => {
+        if (!onSetLog) return;
+        onSetLog(exercise.id, { sets: updatedSets, notes: updatedNote || note || undefined });
+        // Also write summary to legacy loggedData for backward compat
+        const summary = summarizeSets(updatedSets, hasWeight);
+        if (summary) {
+            onLog(exercise.id, { weight: summary });
+        }
+    }, [exercise.id, hasWeight, note, onLog, onSetLog]);
+
+    const handleSetWeightChange = (index: number, value: string) => {
+        const numVal = value === '' ? undefined : parseFloat(value);
+        const updated = setLogs.map((s, i) =>
+            i === index ? { ...s, weight: isNaN(numVal as number) ? undefined : numVal } : s
+        );
+        setSetLogs(updated);
+        emitSetLog(updated);
+    };
+
+    const handleSetRepsChange = (index: number, value: string) => {
+        const numVal = value === '' ? undefined : parseInt(value);
+        const updated = setLogs.map((s, i) =>
+            i === index ? { ...s, reps: isNaN(numVal as number) ? undefined : numVal } : s
+        );
+        setSetLogs(updated);
+        emitSetLog(updated);
+    };
+
+    const handleAddSet = () => {
+        const lastSet = setLogs[setLogs.length - 1];
+        const newSet: SetLog = {
+            setNumber: setLogs.length + 1,
+            weight: lastSet?.weight,
+            weightUnit: lastSet?.weightUnit || 'lbs',
+            reps: lastSet?.reps,
+        };
+        const updated = [...setLogs, newSet];
+        setSetLogs(updated);
+        emitSetLog(updated);
+    };
+
+    const handleRemoveSet = (index: number) => {
+        if (setLogs.length <= 1) return;
+        const updated = setLogs
+            .filter((_, i) => i !== index)
+            .map((s, i) => ({ ...s, setNumber: i + 1 }));
+        setSetLogs(updated);
+        emitSetLog(updated);
+    };
+
+    // Legacy single-input handlers
     const handleWeightChange = (v: string) => {
         setWeight(v);
         onLog(exercise.id, { weight: v });
@@ -84,6 +202,9 @@ export const ActiveExerciseCard = ({
 
     const handleNoteSave = (v: string) => {
         setNote(v);
+        if (showPerSetInputs) {
+            emitSetLog(setLogs, v);
+        }
         onLog(exercise.id, { notes: v });
     };
 
@@ -211,8 +332,113 @@ export const ActiveExerciseCard = ({
                         </div>
                     )}
 
-                    {/* Weight / Reps Inputs */}
-                    {showInputs && (
+                    {/* Per-Set Inputs */}
+                    {showPerSetInputs && (
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>
+                            {/* Column headers */}
+                            <div style={{
+                                display: 'grid',
+                                gridTemplateColumns: hasWeight ? 'auto 1fr 1fr auto' : 'auto 1fr auto',
+                                gap: 'var(--spacing-200)',
+                                alignItems: 'center',
+                            }}>
+                                <span
+                                    className="text-label-xs"
+                                    style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)', minWidth: 40 }}
+                                >
+                                    Set
+                                </span>
+                                {hasWeight && (
+                                    <span
+                                        className="text-label-xs"
+                                        style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)' }}
+                                    >
+                                        Weight
+                                    </span>
+                                )}
+                                <span
+                                    className="text-label-xs"
+                                    style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)' }}
+                                >
+                                    Reps
+                                </span>
+                                {/* Spacer for remove button column */}
+                                <span style={{ width: 28 }} />
+                            </div>
+
+                            {/* Set rows */}
+                            {setLogs.map((set, index) => (
+                                <div
+                                    key={set.setNumber}
+                                    style={{
+                                        display: 'grid',
+                                        gridTemplateColumns: hasWeight ? 'auto 1fr 1fr auto' : 'auto 1fr auto',
+                                        gap: 'var(--spacing-200)',
+                                        alignItems: 'center',
+                                    }}
+                                >
+                                    <span
+                                        className="text-label-xs"
+                                        style={{ fontWeight: 'bold', textTransform: 'uppercase', color: 'var(--text-disabled)', minWidth: 40 }}
+                                    >
+                                        {set.setNumber}
+                                    </span>
+                                    {hasWeight && (
+                                        <Input
+                                            type="number"
+                                            inputMode="decimal"
+                                            value={set.weight != null ? String(set.weight) : ''}
+                                            onChange={(e) => handleSetWeightChange(index, e.target.value)}
+                                            placeholder="lbs"
+                                        />
+                                    )}
+                                    <Input
+                                        type="number"
+                                        inputMode="numeric"
+                                        value={set.reps != null ? String(set.reps) : ''}
+                                        onChange={(e) => handleSetRepsChange(index, e.target.value)}
+                                        placeholder={exercise.reps}
+                                    />
+                                    <button
+                                        onClick={() => handleRemoveSet(index)}
+                                        style={{
+                                            width: 28,
+                                            height: 28,
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'center',
+                                            color: 'var(--text-disabled)',
+                                            opacity: setLogs.length <= 1 ? 0.3 : 1,
+                                        }}
+                                        disabled={setLogs.length <= 1}
+                                    >
+                                        <X size={14} />
+                                    </button>
+                                </div>
+                            ))}
+
+                            {/* Add set button */}
+                            <button
+                                onClick={handleAddSet}
+                                className="text-cta-xs"
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 'var(--spacing-100)',
+                                    textTransform: 'uppercase',
+                                    letterSpacing: '0.05em',
+                                    color: 'var(--text-cta)',
+                                    paddingTop: 'var(--spacing-100)',
+                                }}
+                            >
+                                <Plus size={14} />
+                                Add Set
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Legacy single Weight / Reps Inputs (non per-set exercises) */}
+                    {showInputs && !showPerSetInputs && (
                         <div style={hasWeight ? { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--spacing-300)' } : undefined}>
                             {hasWeight && (
                                 <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>

--- a/src/components/workout/SectionRenderer.tsx
+++ b/src/components/workout/SectionRenderer.tsx
@@ -1,4 +1,4 @@
-import { WorkoutSection, Exercise } from "@/types/workout";
+import { WorkoutSection, Exercise, ExerciseSetData } from "@/types/workout";
 import { ActiveExerciseCard } from "./ActiveExerciseCard";
 import { isLadderReps, parseRungs } from "./LadderRungs";
 import { Card } from "../Card";
@@ -20,6 +20,8 @@ export interface StructureResultData {
 interface SectionRendererProps {
     section: WorkoutSection;
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
+    /** Called with per-set data for exercises that use set-by-set logging */
+    onSetLog?: (id: string, data: ExerciseSetData) => void;
     /** Called when a timed section completes with structure-level result data */
     onStructureResult?: (sectionId: string, data: StructureResultData) => void;
 }
@@ -81,6 +83,7 @@ function groupExercises(exercises: Exercise[]) {
 export const SectionRenderer = ({
     section,
     onLog,
+    onSetLog,
     onStructureResult,
 }: SectionRendererProps) => {
 
@@ -127,6 +130,7 @@ export const SectionRenderer = ({
                             <ActiveExerciseCard
                                 exercise={exercise}
                                 onLog={onLog}
+                                onSetLog={onSetLog}
                                 sectionType={section.type}
                                 bare
                             />
@@ -167,6 +171,7 @@ export const SectionRenderer = ({
                                     key={`group-${idx}`}
                                     exercises={group.exercises}
                                     onLog={onLog}
+                                    onSetLog={onSetLog}
                                     sectionType={section.type}
                                     structure={group.structure}
                                 />
@@ -204,6 +209,7 @@ export const SectionRenderer = ({
                                         <ActiveExerciseCard
                                             exercise={ex}
                                             onLog={onLog}
+                                            onSetLog={onSetLog}
                                             sectionType={section.type}
                                             bare
                                             defaultExpanded={standaloneExercises.length === 1}

--- a/src/components/workout/StructureCards.tsx
+++ b/src/components/workout/StructureCards.tsx
@@ -1,10 +1,11 @@
-import { ExerciseStructure, Exercise } from "@/types/workout";
+import { ExerciseStructure, Exercise, ExerciseSetData } from "@/types/workout";
 import { ActiveExerciseCard } from "./ActiveExerciseCard";
 import { Card } from "../Card";
 
 interface StructureCardProps {
     exercises: Exercise[];
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
+    onSetLog?: (id: string, data: ExerciseSetData) => void;
     sectionType?: string;
     sectionName?: string;
     structure: ExerciseStructure;
@@ -17,7 +18,7 @@ const hasRest = (rest?: string): boolean => {
     return cleaned !== '0s' && cleaned !== '0' && cleaned !== '';
 };
 
-export const SupersetCard = ({ exercises, onLog, sectionType }: StructureCardProps) => {
+export const SupersetCard = ({ exercises, onLog, onSetLog, sectionType }: StructureCardProps) => {
     // Get the shared rest from the last exercise
     const lastExercise = exercises[exercises.length - 1];
     const pairRest = hasRest(lastExercise?.rest) ? lastExercise.rest : null;
@@ -47,6 +48,7 @@ export const SupersetCard = ({ exercises, onLog, sectionType }: StructureCardPro
                             key={exercise.id}
                             exercise={exercise}
                             onLog={onLog}
+                            onSetLog={onSetLog}
                             sectionType={sectionType}
                             bare
                             pairLabel={`A${i + 1}`}

--- a/src/components/workout/SupersetRenderer.tsx
+++ b/src/components/workout/SupersetRenderer.tsx
@@ -1,9 +1,10 @@
-import { Exercise } from "@/types/workout";
+import { Exercise, ExerciseSetData } from "@/types/workout";
 import { SupersetCard } from "./StructureCards";
 
 interface SupersetRendererProps {
     exercises: Exercise[];
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
+    onSetLog?: (id: string, data: ExerciseSetData) => void;
     sectionType: string;
     structure: NonNullable<Exercise['structure']>;
 }
@@ -12,6 +13,7 @@ interface SupersetRendererProps {
 export const SupersetRenderer = ({
     exercises,
     onLog,
+    onSetLog,
     sectionType,
     structure,
 }: SupersetRendererProps) => {
@@ -19,6 +21,7 @@ export const SupersetRenderer = ({
         <SupersetCard
             exercises={exercises}
             onLog={onLog}
+            onSetLog={onSetLog}
             sectionType={sectionType}
             sectionName={sectionType.replace('_', ' ')}
             structure={structure}

--- a/src/hooks/useWorkoutGeneration.ts
+++ b/src/hooks/useWorkoutGeneration.ts
@@ -16,9 +16,48 @@ import {
     transformAPIWorkoutToFrontend,
     saveGeneratedWorkout,
     injectDBUUIDs,
+    fetchLastSetData,
 } from "@/lib/workout-api";
 import type { SavedWorkoutUUIDs } from "@/lib/workout-api";
 import { resolveAnchorToPattern } from "@/lib/anchor-mapping";
+
+/**
+ * Fetch last set data for all exercises in a workout and attach as pre-fill.
+ * Looks up by exerciseDefinitionId, falls back to legacy weight_logged.
+ */
+async function injectLastSetData(workout: GeneratedWorkout): Promise<GeneratedWorkout> {
+    // Collect all exercise definition IDs
+    const defIds = new Set<string>();
+    for (const section of workout.sections) {
+        for (const ex of section.exercises) {
+            if (ex.exerciseDefinitionId) defIds.add(ex.exerciseDefinitionId);
+        }
+    }
+
+    if (defIds.size === 0) return workout;
+
+    const { setData, legacyData } = await fetchLastSetData(Array.from(defIds));
+
+    // Attach to exercises
+    return {
+        ...workout,
+        sections: workout.sections.map(section => ({
+            ...section,
+            exercises: section.exercises.map(ex => {
+                if (!ex.exerciseDefinitionId) return ex;
+                const sets = setData[ex.exerciseDefinitionId];
+                if (sets) {
+                    return { ...ex, lastSetData: sets };
+                }
+                const legacy = legacyData[ex.exerciseDefinitionId];
+                if (legacy) {
+                    return { ...ex, lastWeight: ex.lastWeight || legacy };
+                }
+                return ex;
+            }),
+        })),
+    };
+}
 
 export const useWorkoutGeneration = (
     userPreferences: UserPreferences,
@@ -171,6 +210,9 @@ export const useWorkoutGeneration = (
                         exercises: savedUUIDs.sections.reduce((sum, s) => sum + s.exercises.length, 0),
                     });
                 }
+
+                // Pre-fill from last session data
+                workout = await injectLastSetData(workout);
 
                 setGeneratedWorkout(workout);
                 toast.success("Workout generated!", {

--- a/src/hooks/useWorkoutSession.ts
+++ b/src/hooks/useWorkoutSession.ts
@@ -5,7 +5,7 @@ import {
     GeneratedWorkout,
     WorkoutNotes,
 } from "@/types/workout";
-import { completeWorkoutSession, fetchSessionForRepeat, createRepeatSession, buildWorkoutFromSections, injectDBUUIDs } from "@/lib/workout-api";
+import { completeWorkoutSession, fetchSessionForRepeat, createRepeatSession, buildWorkoutFromSections, injectDBUUIDs, fetchLastSetData } from "@/lib/workout-api";
 import { fetchWorkoutDetail } from "@/lib/home-data";
 import { getFavoriteDetail, recordFavoriteCompletion, getLastExerciseData, getPreviousBests, getSessionNotesHistory } from "@/lib/favorites-api";
 import type { RepeatSectionInput } from "@/lib/workout-api";
@@ -58,6 +58,7 @@ export const useWorkoutSession = ({
                     mood,
                     sessionNotes,
                     loggedData: workoutNotes?.loggedData,
+                    setLogData: workoutNotes?.setLogData,
                     structureResults: workoutNotes?.structureResults,
                 });
 
@@ -172,6 +173,31 @@ export const useWorkoutSession = ({
 
         workout = injectDBUUIDs(workout, saveResult.uuids);
 
+        // Pre-fill from last set data
+        const defIds = new Set<string>();
+        for (const section of workout.sections) {
+            for (const ex of section.exercises) {
+                if (ex.exerciseDefinitionId) defIds.add(ex.exerciseDefinitionId);
+            }
+        }
+        if (defIds.size > 0) {
+            const { setData, legacyData } = await fetchLastSetData(Array.from(defIds));
+            workout = {
+                ...workout,
+                sections: workout.sections.map(section => ({
+                    ...section,
+                    exercises: section.exercises.map(ex => {
+                        if (!ex.exerciseDefinitionId) return ex;
+                        const sets = setData[ex.exerciseDefinitionId];
+                        if (sets) return { ...ex, lastSetData: sets };
+                        const legacy = legacyData[ex.exerciseDefinitionId];
+                        if (legacy) return { ...ex, lastWeight: ex.lastWeight || legacy };
+                        return ex;
+                    }),
+                })),
+            };
+        }
+
         setGeneratedWorkout(workout);
         setCurrentSessionId(saveResult.sessionId);
         setIsRepeat(true);
@@ -254,6 +280,31 @@ export const useWorkoutSession = ({
 
         if (notesHistory.length > 0) {
             workout = { ...workout, sessionNotesHistory: notesHistory };
+        }
+
+        // Pre-fill per-set data from last session
+        const defIds = new Set<string>();
+        for (const section of workout.sections) {
+            for (const ex of section.exercises) {
+                if (ex.exerciseDefinitionId) defIds.add(ex.exerciseDefinitionId);
+            }
+        }
+        if (defIds.size > 0) {
+            const { setData, legacyData } = await fetchLastSetData(Array.from(defIds));
+            workout = {
+                ...workout,
+                sections: workout.sections.map(section => ({
+                    ...section,
+                    exercises: section.exercises.map(ex => {
+                        if (!ex.exerciseDefinitionId) return ex;
+                        const sets = setData[ex.exerciseDefinitionId];
+                        if (sets) return { ...ex, lastSetData: sets };
+                        const legacy = legacyData[ex.exerciseDefinitionId];
+                        if (legacy) return { ...ex, lastWeight: ex.lastWeight || legacy };
+                        return ex;
+                    }),
+                })),
+            };
         }
 
         setGeneratedWorkout(workout);

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -224,6 +224,27 @@ export async function fetchWorkoutDetail(sessionId: string): Promise<import('@/t
     }
   }
 
+  // Fetch per-set logs for all exercises
+  const allExerciseIds = (sections || []).flatMap(s =>
+    (s.exercises || []).map((ex: { id: string }) => ex.id)
+  );
+  let setLogsMap: Record<string, Array<{ set_number: number; weight: number | null; weight_unit: string | null; reps: number | null; rpe: number | null }>> = {};
+  if (allExerciseIds.length > 0) {
+    const { data: setData } = await supabase
+      .from('exercise_set_logs')
+      .select('exercise_row_id, set_number, weight, weight_unit, reps, rpe')
+      .in('exercise_row_id', allExerciseIds)
+      .order('set_number', { ascending: true });
+    if (setData) {
+      for (const row of setData) {
+        if (!setLogsMap[row.exercise_row_id]) {
+          setLogsMap[row.exercise_row_id] = [];
+        }
+        setLogsMap[row.exercise_row_id].push(row);
+      }
+    }
+  }
+
   // Map section type to display name
   const sectionNameMap: Record<string, string> = {
     warmup: 'Warm-up',
@@ -256,17 +277,27 @@ export async function fetchWorkoutDetail(sessionId: string): Promise<import('@/t
       name: sectionNameMap[section.section_type] || section.section_type,
       exercises: (section.exercises || [])
         .sort((a: { order_index?: number }, b: { order_index?: number }) => (a.order_index || 0) - (b.order_index || 0))
-        .map((ex: Database['public']['Tables']['exercises']['Row']) => ({
-          id: ex.id,
-          name: ex.exercise_id?.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()) || 'Unknown',
-          sets: ex.sets || 1,
-          reps: ex.reps || '—',
-          weight: ex.weight_logged || undefined,
-          note: ex.exercise_notes || undefined,
-          equipment: ex.equipment_used && ex.equipment_used !== 'bodyweight'
-            ? ex.equipment_used.replace(/_/g, ' ')
-            : undefined,
-        })),
+        .map((ex: Database['public']['Tables']['exercises']['Row']) => {
+          const exerciseSetLogs = setLogsMap[ex.id];
+          return {
+            id: ex.id,
+            name: ex.exercise_id?.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()) || 'Unknown',
+            sets: ex.sets || 1,
+            reps: ex.reps || '—',
+            weight: ex.weight_logged || undefined,
+            note: ex.exercise_notes || undefined,
+            equipment: ex.equipment_used && ex.equipment_used !== 'bodyweight'
+              ? ex.equipment_used.replace(/_/g, ' ')
+              : undefined,
+            setLogs: exerciseSetLogs?.map(sl => ({
+              setNumber: sl.set_number,
+              weight: sl.weight ?? undefined,
+              weightUnit: (sl.weight_unit as 'lbs' | 'kg') || 'lbs',
+              reps: sl.reps ?? undefined,
+              rpe: sl.rpe ?? undefined,
+            })),
+          };
+        }),
       structureResult,
     };
   });

--- a/src/lib/workout-api.test.ts
+++ b/src/lib/workout-api.test.ts
@@ -124,6 +124,14 @@ describe('transformAPIWorkoutToFrontend', () => {
     expect(squat.regression).toBe('Goblet squat');
   });
 
+  it('injects exerciseDefinitionId from exercise_id', () => {
+    const result = transformAPIWorkoutToFrontend(makeAPIWorkout(), 5, 'squat');
+    const warmupEx = result.sections[0].exercises[0];
+    const primaryEx = result.sections[1].exercises[0];
+    expect(warmupEx.exerciseDefinitionId).toBe('jumping-jacks');
+    expect(primaryEx.exerciseDefinitionId).toBe('back-squat');
+  });
+
   it('preserves string reps like "30 sec"', () => {
     const api = makeAPIWorkout({
       sections: [

--- a/src/lib/workout-api.ts
+++ b/src/lib/workout-api.ts
@@ -11,7 +11,7 @@ import type {
   GenerationError,
   GeneratedWorkout as APIGeneratedWorkout,
 } from '@/types/generation';
-import type { GeneratedWorkout, WorkoutSection, Exercise, SectionType } from '@/types/workout';
+import type { GeneratedWorkout, WorkoutSection, Exercise, SectionType, SetLog, ExerciseSetData } from '@/types/workout';
 import type { Database } from '@/types/database';
 import { DB_TO_SECTION } from './section-mapping';
 
@@ -40,6 +40,7 @@ export function transformAPIWorkoutToFrontend(
 
     const exercises: Exercise[] = section.exercises.map((ex, exIndex) => ({
       id: ex.exercise_id || `${section.section_type}-${exIndex}`,
+      exerciseDefinitionId: ex.exercise_id || undefined,
       name: ex.name,
       sets: ex.sets || 1,
       reps: typeof ex.reps === 'string' && ex.reps.includes(' ')
@@ -364,6 +365,7 @@ export async function completeWorkoutSession(
     mood: number | null;
     sessionNotes: string;
     loggedData?: Record<string, { weight?: string; reps?: string; notes?: string }>;
+    setLogData?: Record<string, ExerciseSetData>;
     structureResults?: Record<string, {
       structure_type: string;
       rounds_completed?: number;
@@ -426,6 +428,41 @@ export async function completeWorkoutSession(
         });
       } else {
         logger.workout.info(`${exerciseEntries.length} exercise(s) logged`, { sessionId });
+      }
+    }
+  }
+
+  // 2b. Persist per-set log data
+  if (data.setLogData) {
+    const setLogEntries = Object.entries(data.setLogData).filter(
+      ([, entry]) => entry.sets.length > 0
+    );
+
+    if (setLogEntries.length > 0) {
+      const allSetRows = setLogEntries.flatMap(([exerciseId, entry]) =>
+        entry.sets.map(set => ({
+          exercise_row_id: exerciseId,
+          set_number: set.setNumber,
+          weight: set.weight ?? null,
+          weight_unit: set.weightUnit || 'lbs',
+          reps: set.reps ?? null,
+          rpe: set.rpe ?? null,
+        }))
+      );
+
+      const { error: setLogError } = await supabase
+        .from('exercise_set_logs')
+        .insert(allSetRows);
+
+      if (setLogError) {
+        partialFailureCount++;
+        logger.workout.warn('exercise_set_logs insert failed', {
+          sessionId,
+          error: setLogError.message,
+          rowCount: allSetRows.length,
+        });
+      } else {
+        logger.workout.info(`${allSetRows.length} set log(s) saved`, { sessionId });
       }
     }
   }
@@ -652,6 +689,7 @@ export function buildWorkoutFromSections(
     status: 'not_started' as const,
     exercises: section.exercises.map((ex, eIndex) => ({
       id: `${section.section_type}-${sIndex}-ex-${eIndex}`,
+      exerciseDefinitionId: ex.exercise_id || undefined,
       name: ex.exercise_id?.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()) || 'Unknown Exercise',
       sets: ex.sets,
       reps: ex.reps,
@@ -674,5 +712,37 @@ export function buildWorkoutFromSections(
     anchor: metadata.anchor.toUpperCase(),
     goal: metadata.goal,
     sections,
+  };
+}
+
+/**
+ * Fetch the last set data for a list of exercise definition IDs.
+ * Returns per-set history from the most recent completed session,
+ * with legacy weight_logged fallback for pre-migration data.
+ */
+export async function fetchLastSetData(
+  exerciseDefinitionIds: string[]
+): Promise<{ setData: Record<string, SetLog[]>; legacyData: Record<string, string> }> {
+  if (exerciseDefinitionIds.length === 0) {
+    return { setData: {}, legacyData: {} };
+  }
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { setData: {}, legacyData: {} };
+
+  const { data, error } = await supabase.rpc('get_last_set_data', {
+    p_user_id: user.id,
+    p_exercise_definition_ids: exerciseDefinitionIds,
+  });
+
+  if (error) {
+    logger.workout.warn('fetchLastSetData RPC failed', { error: error.message });
+    return { setData: {}, legacyData: {} };
+  }
+
+  const result = data as { setData: Record<string, SetLog[]>; legacyData: Record<string, string> } | null;
+  return {
+    setData: result?.setData || {},
+    legacyData: result?.legacyData || {},
   };
 }

--- a/src/pages/SessionDetailScreen.tsx
+++ b/src/pages/SessionDetailScreen.tsx
@@ -81,9 +81,9 @@ function StructureResultBadge({ result }: { result: LoggedStructureResult }) {
   );
 }
 
-/** Check if a section has any logged data (weights or notes) */
+/** Check if a section has any logged data (weights, notes, or set logs) */
 function sectionHasLoggedData(section: LoggedSection): boolean {
-  return section.exercises.some(ex => ex.weight || ex.note);
+  return section.exercises.some(ex => ex.weight || ex.note || (ex.setLogs && ex.setLogs.length > 0));
 }
 
 /** Collapsible section: exercises always visible, expand to see logged weights/notes */
@@ -156,17 +156,34 @@ function SectionBlock({ section }: { section: LoggedSection }) {
               {exercise.equipment && ` • ${exercise.equipment}`}
             </p>
 
-            {/* Logged data: weight + notes — only when expanded */}
+            {/* Logged data: per-set breakdown or legacy weight — only when expanded */}
             {expanded && (
               <>
-                {exercise.weight && (
+                {exercise.setLogs && exercise.setLogs.length > 0 ? (
+                  <div style={{ marginTop: 'var(--spacing-100)', display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    {exercise.setLogs.map(set => (
+                      <p
+                        key={set.setNumber}
+                        className="text-label-xs"
+                        style={{ fontWeight: 700, color: 'var(--text-timer)' }}
+                      >
+                        <span style={{ color: 'var(--text-disabled)', marginRight: 'var(--spacing-200)' }}>
+                          Set {set.setNumber}
+                        </span>
+                        {set.weight != null && `${set.weight} ${set.weightUnit || 'lbs'}`}
+                        {set.weight != null && set.reps != null && ' × '}
+                        {set.reps != null && `${set.reps}`}
+                      </p>
+                    ))}
+                  </div>
+                ) : exercise.weight ? (
                   <p
                     className="text-label-xs"
                     style={{ marginTop: 'var(--spacing-100)', fontWeight: 700, color: 'var(--text-timer)' }}
                   >
                     {exercise.weight}
                   </p>
-                )}
+                ) : null}
 
                 {exercise.note && (
                   <p

--- a/src/pages/WorkoutScreen.tsx
+++ b/src/pages/WorkoutScreen.tsx
@@ -6,6 +6,7 @@ import { WorkoutLayout } from "@/layouts";
 import { SectionRenderer, StructureResultData } from "@/components/workout/SectionRenderer";
 import { ProgressTracker } from "@/components/workout/ProgressTracker";
 import { useWorkoutFlowContext } from "@/contexts/WorkoutFlowContext";
+import type { ExerciseSetData } from "@/types/workout";
 
 type LoggedExerciseData = Record<string, { weight?: string; reps?: string; notes?: string }>;
 
@@ -14,6 +15,7 @@ export const WorkoutScreen = () => {
   const { generatedWorkout, handleFinishWorkout } = useWorkoutFlowContext();
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const [loggedData, setLoggedData] = useState<LoggedExerciseData>({});
+  const [setLogData, setSetLogData] = useState<Record<string, ExerciseSetData>>({});
   const [structureResults, setStructureResults] = useState<Record<string, StructureResultData>>({});
 
   const touchStartX = useRef<number | null>(null);
@@ -56,6 +58,7 @@ export const WorkoutScreen = () => {
     if (isLastSection) {
       handleFinishWorkout({
         loggedData,
+        setLogData: Object.keys(setLogData).length > 0 ? setLogData : undefined,
         structureResults,
         durationSeconds: Math.floor((Date.now() - startTime.current) / 1000)
       }, () => navigate("/summary"));
@@ -71,6 +74,10 @@ export const WorkoutScreen = () => {
       [id]: { ...(prev[id] || {}), ...data }
     }));
   };
+
+  const handleSetLog = useCallback((id: string, data: ExerciseSetData) => {
+    setSetLogData(prev => ({ ...prev, [id]: data }));
+  }, []);
 
   const handleStructureResult = useCallback((sectionId: string, data: StructureResultData) => {
     setStructureResults(prev => ({ ...prev, [sectionId]: data }));
@@ -113,6 +120,7 @@ export const WorkoutScreen = () => {
         key={currentSectionIndex}
         section={currentSection}
         onLog={handleLog}
+        onSetLog={handleSetLog}
         onStructureResult={handleStructureResult}
       />
     </WorkoutLayout>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,38 +1,4 @@
 Connecting to db 5432
-v0.96.4: Pulling from supabase/postgres-meta
-2705dbac373a: Pulling fs layer
-1dbbb2db815c: Pulling fs layer
-c8f3ed040281: Pulling fs layer
-1e2be9f8a111: Pulling fs layer
-78e1f2f65955: Pulling fs layer
-f6bc6564f93a: Pulling fs layer
-f4c396aa930d: Pulling fs layer
-9c6243177b72: Pulling fs layer
-53fdaf778fe7: Pulling fs layer
-49981ae38b77: Pulling fs layer
-dd0e679da763: Download complete
-49981ae38b77: Download complete
-9c6243177b72: Download complete
-c8f3ed040281: Download complete
-f6bc6564f93a: Download complete
-2705dbac373a: Download complete
-78e1f2f65955: Download complete
-f4c396aa930d: Download complete
-1e2be9f8a111: Download complete
-53fdaf778fe7: Download complete
-1dbbb2db815c: Download complete
-c8f3ed040281: Pull complete
-1dbbb2db815c: Pull complete
-9c6243177b72: Pull complete
-f6bc6564f93a: Pull complete
-78e1f2f65955: Pull complete
-f4c396aa930d: Pull complete
-1e2be9f8a111: Pull complete
-49981ae38b77: Pull complete
-53fdaf778fe7: Pull complete
-2705dbac373a: Pull complete
-Digest: sha256:4dd3e0ff3e9a0f9f62dd1a1a827f124645549b439ddb2a53598575744585e32d
-Status: Downloaded newer image for public.ecr.aws/supabase/postgres-meta:v0.96.4
 export type Json =
   | string
   | number
@@ -221,6 +187,57 @@ export type Database = {
             columns: ["exercise_id"]
             isOneToOne: false
             referencedRelation: "exercise_definitions_with_anchors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      exercise_set_logs: {
+        Row: {
+          created_at: string | null
+          exercise_row_id: string
+          id: string
+          is_warmup_set: boolean | null
+          reps: number | null
+          rpe: number | null
+          set_number: number
+          weight: number | null
+          weight_unit: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          exercise_row_id: string
+          id?: string
+          is_warmup_set?: boolean | null
+          reps?: number | null
+          rpe?: number | null
+          set_number: number
+          weight?: number | null
+          weight_unit?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          exercise_row_id?: string
+          id?: string
+          is_warmup_set?: boolean | null
+          reps?: number | null
+          rpe?: number | null
+          set_number?: number
+          weight?: number | null
+          weight_unit?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercise_set_logs_exercise_row_id_fkey"
+            columns: ["exercise_row_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "exercise_set_logs_exercise_row_id_fkey"
+            columns: ["exercise_row_id"]
+            isOneToOne: false
+            referencedRelation: "exercises_with_context"
             referencedColumns: ["id"]
           },
         ]
@@ -855,6 +872,10 @@ export type Database = {
         }
         Returns: string
       }
+      get_last_set_data: {
+        Args: { p_exercise_definition_ids: string[]; p_user_id: string }
+        Returns: Json
+      }
       save_generated_workout: {
         Args: {
           p_anchor: Database["public"]["Enums"]["anchor_type"]
@@ -869,6 +890,7 @@ export type Database = {
         }
         Returns: Json
       }
+      suggest_anchor: { Args: { p_user_id: string }; Returns: Json }
     }
     Enums: {
       anchor_type:

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -4,6 +4,21 @@ export type AnchorType = 'LOWER BODY' | 'UPPER BODY' | 'FULL BODY' | 'POWER' | '
 // Movement patterns (what gets sent to API and stored in DB)
 export type MovementPattern = 'squat' | 'hinge' | 'press' | 'pull' | 'power';
 
+// Per-set log data
+export interface SetLog {
+  setNumber: number;
+  weight?: number;
+  weightUnit?: 'lbs' | 'kg';
+  reps?: number;
+  rpe?: number;
+}
+
+// Aggregated set data for an exercise
+export interface ExerciseSetData {
+  sets: SetLog[];
+  notes?: string;
+}
+
 // Exercise with logged data for history
 export interface LoggedExercise {
   id: string;
@@ -13,6 +28,7 @@ export interface LoggedExercise {
   weight?: string; // logged weight like "185lbs"
   note?: string; // user note for this exercise
   equipment?: string; // equipment used (e.g. "barbell", "dumbbells")
+  setLogs?: SetLog[]; // per-set breakdown (new sessions)
 }
 
 // Structure result from a timed section (AMRAP/For Time/EMOM)
@@ -171,6 +187,8 @@ export interface Exercise {
   rest?: string;
   lastWeight?: string;
   lastNotes?: string;
+  lastSetData?: SetLog[]; // Per-set pre-fill from previous session
+  exerciseDefinitionId?: string; // exercise_definitions.exercise_id for pre-fill lookup
   coachingCues?: string[]; // Changed to array
   regression?: string;
   progression?: string;
@@ -217,6 +235,7 @@ export interface WorkoutParams {
 // Workout notes collected during and after workout
 export interface WorkoutNotes {
   loggedData: Record<string, { weight?: string; reps?: string; notes?: string }>;
+  setLogData?: Record<string, ExerciseSetData>; // Per-set data keyed by exercise row UUID
   structureResults: Record<string, {
     structure_type: string;
     rounds_completed?: number;

--- a/supabase/migrations/00028_exercise_set_logs.sql
+++ b/supabase/migrations/00028_exercise_set_logs.sql
@@ -1,0 +1,70 @@
+-- Exercise Set Logs: per-set weight/reps tracking
+-- Enables set-by-set logging (e.g., 135x10, 155x8, 175x6, 185x4)
+
+CREATE TABLE exercise_set_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  exercise_row_id UUID NOT NULL REFERENCES exercises(id) ON DELETE CASCADE,
+  set_number SMALLINT NOT NULL,
+  weight NUMERIC,
+  weight_unit TEXT DEFAULT 'lbs' CHECK (weight_unit IN ('lbs', 'kg')),
+  reps SMALLINT,
+  rpe NUMERIC CHECK (rpe IS NULL OR (rpe >= 1 AND rpe <= 10)),
+  is_warmup_set BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(exercise_row_id, set_number)
+);
+
+CREATE INDEX idx_exercise_set_logs_exercise ON exercise_set_logs(exercise_row_id);
+
+ALTER TABLE exercise_set_logs ENABLE ROW LEVEL SECURITY;
+
+-- RLS: users can only access set logs for their own exercises
+-- Join chain: exercise_set_logs → exercises → workout_sections → workout_sessions → user_id
+
+CREATE POLICY "Users can view their own set logs"
+  ON exercise_set_logs FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM exercises e
+      JOIN workout_sections ws ON ws.id = e.section_id
+      JOIN workout_sessions s ON s.id = ws.session_id
+      WHERE e.id = exercise_set_logs.exercise_row_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert their own set logs"
+  ON exercise_set_logs FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM exercises e
+      JOIN workout_sections ws ON ws.id = e.section_id
+      JOIN workout_sessions s ON s.id = ws.session_id
+      WHERE e.id = exercise_set_logs.exercise_row_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can update their own set logs"
+  ON exercise_set_logs FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM exercises e
+      JOIN workout_sections ws ON ws.id = e.section_id
+      JOIN workout_sessions s ON s.id = ws.session_id
+      WHERE e.id = exercise_set_logs.exercise_row_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete their own set logs"
+  ON exercise_set_logs FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM exercises e
+      JOIN workout_sections ws ON ws.id = e.section_id
+      JOIN workout_sessions s ON s.id = ws.session_id
+      WHERE e.id = exercise_set_logs.exercise_row_id
+        AND s.user_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/00029_get_last_set_data_rpc.sql
+++ b/supabase/migrations/00029_get_last_set_data_rpc.sql
@@ -1,0 +1,72 @@
+-- RPC: get_last_set_data
+-- Returns per-exercise set history from the most recent completed session
+-- for each given exercise_definition_id. Falls back to legacy weight_logged
+-- for pre-migration data.
+
+CREATE OR REPLACE FUNCTION get_last_set_data(
+  p_user_id UUID,
+  p_exercise_definition_ids TEXT[]
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  result JSON;
+BEGIN
+  WITH latest_exercises AS (
+    -- Find the most recent exercise row for each definition_id
+    SELECT DISTINCT ON (e.exercise_id)
+      e.id AS exercise_row_id,
+      e.exercise_id AS definition_id,
+      e.weight_logged,
+      s.completed_at
+    FROM exercises e
+    JOIN workout_sections ws ON ws.id = e.section_id
+    JOIN workout_sessions s ON s.id = ws.session_id
+    WHERE s.user_id = p_user_id
+      AND s.completed_at IS NOT NULL
+      AND e.exercise_id = ANY(p_exercise_definition_ids)
+    ORDER BY e.exercise_id, s.completed_at DESC
+  ),
+  set_data AS (
+    -- Get set logs for those exercise rows
+    SELECT
+      le.definition_id,
+      json_agg(
+        json_build_object(
+          'setNumber', esl.set_number,
+          'weight', esl.weight,
+          'weightUnit', esl.weight_unit,
+          'reps', esl.reps,
+          'rpe', esl.rpe
+        ) ORDER BY esl.set_number
+      ) AS sets
+    FROM latest_exercises le
+    JOIN exercise_set_logs esl ON esl.exercise_row_id = le.exercise_row_id
+    GROUP BY le.definition_id
+  ),
+  legacy_data AS (
+    -- Fallback: exercises without set logs use weight_logged
+    SELECT
+      le.definition_id,
+      le.weight_logged
+    FROM latest_exercises le
+    LEFT JOIN exercise_set_logs esl ON esl.exercise_row_id = le.exercise_row_id
+    WHERE esl.id IS NULL
+      AND le.weight_logged IS NOT NULL
+  )
+  SELECT json_build_object(
+    'setData', COALESCE(
+      (SELECT json_object_agg(definition_id, sets) FROM set_data),
+      '{}'::json
+    ),
+    'legacyData', COALESCE(
+      (SELECT json_object_agg(definition_id, weight_logged) FROM legacy_data),
+      '{}'::json
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$$;


### PR DESCRIPTION
## Summary
- New `exercise_set_logs` table for per-set weight/reps/RPE tracking
- RPC `get_last_set_data` fetches previous session data for pre-filling inputs
- ActiveExerciseCard shows per-set inputs for weighted exercises
- Session detail screen displays set-by-set breakdown
- Legacy `weight_logged` fallback preserved for pre-migration data
- Session log update (session 19)

## Test plan
- [ ] Generate a workout with weighted exercises — verify per-set input rows appear
- [ ] Complete a workout logging sets — verify data saves to `exercise_set_logs`
- [ ] Start a new workout with the same exercises — verify last session data pre-fills
- [ ] Check session detail screen shows set-by-set breakdown
- [ ] Verify legacy sessions (pre-migration) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)