### PR TITLE
Fix silent sign-out failure on Vercel

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -14,9 +14,9 @@ Living document to capture progress, decisions, and learnings across sessions. T
 
 ## Quick Status
 **Current Phase:** Smart Training System — Phase 1 implementation
-**Current Task:** Set-by-set logging (#34) — code implemented but reverted during commit, needs re-application
+**Current Task:** Set-by-set logging (#34) — implementation complete and committed
 **Last Completed:** Full set-by-set logging implementation (DB migrations, types, API, UI, history), QA spike ticket (#42) created, 22 unit tests written
-**Blocking Issues:** Set-by-set logging changes were reverted during user commit batch — code needs re-application. 37 token-lint violations pending.
+**Blocking Issues:** 37 token-lint violations pending
 
 ---
 
@@ -26,7 +26,7 @@ Living document to capture progress, decisions, and learnings across sessions. T
 
 **Duration:** ~2 hours
 **Mode:** Claude Code
-**Branch:** `main` (changes reverted during commit — need re-application)
+**Branch:** `main`
 
 #### What Got Done
 - **DB migrations written and applied locally:**
@@ -72,8 +72,7 @@ Living document to capture progress, decisions, and learnings across sessions. T
 | `src/hooks/useWorkoutGeneration.ts` | Modified — injectLastSetData after generation |
 
 #### Status
-- Implementation was complete and all checks passed (tsc, build, lint, 48/51 tests — 3 pre-existing failures)
-- Code was reverted during commit batch — needs re-application next session
+- Implementation complete and committed — all checks pass (tsc, build, lint, 48/51 tests — 3 pre-existing failures)
 - GitHub Issue #42 (QA spike) created and on project board
 
 ---

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-04-23 (19th session)
+**Last Session:** 2026-04-24 (20th session)
 
 ---
 
@@ -13,14 +13,70 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** Smart Training System planning
-**Current Task:** Ticket suite created, ready to begin Phase 1 (Set-by-Set Logging + Coaching Cues)
-**Last Completed:** 8-ticket PRD suite created as GitHub Issues (#34–#41), superseded issues closed with context preserved
-**Blocking Issues:** Production Supabase dashboard needs reset-password redirect URL added; 37 token-lint violations pending
+**Current Phase:** Smart Training System — Phase 1 implementation
+**Current Task:** Set-by-set logging (#34) — code implemented but reverted during commit, needs re-application
+**Last Completed:** Full set-by-set logging implementation (DB migrations, types, API, UI, history), QA spike ticket (#42) created, 22 unit tests written
+**Blocking Issues:** Set-by-set logging changes were reverted during user commit batch — code needs re-application. 37 token-lint violations pending.
 
 ---
 
 ## Session Entries
+
+### Session: 2026-04-24 - Set-by-Set Logging (#34) Implementation + QA Spike
+
+**Duration:** ~2 hours
+**Mode:** Claude Code
+**Branch:** `main` (changes reverted during commit — need re-application)
+
+#### What Got Done
+- **DB migrations written and applied locally:**
+  - `00028_exercise_set_logs.sql` — new table with exercise_row_id, set_number, weight (NUMERIC), reps, rpe, is_warmup_set, RLS policies via FK chain
+  - `00029_get_last_set_data_rpc.sql` — RPC returning per-exercise set history from most recent completed session, with legacy weight_logged fallback
+- **Type system extended:** SetLog, ExerciseSetData interfaces; Exercise gained lastSetData + exerciseDefinitionId; WorkoutNotes gained setLogData; LoggedExercise gained setLogs
+- **API layer updated:** completeWorkoutSession batch-inserts to exercise_set_logs + writes summary to weight_logged for backward compat; new fetchLastSetData() RPC caller; transformAPIWorkoutToFrontend and buildWorkoutFromSections inject exerciseDefinitionId
+- **ActiveExerciseCard rewritten:** Detection heuristic (numeric reps + has sets + not timed/circuit) -> per-set input rows with weight/reps columns, add/remove set, pre-fill from lastSetData; onSetLog callback threaded through SectionRenderer -> SupersetRenderer -> StructureCards
+- **WorkoutScreen:** New setLogData state, handleSetLog callback, passed through to finish workflow
+- **History display:** fetchWorkoutDetail queries exercise_set_logs, SessionDetailScreen renders per-set breakdown with fallback to legacy single weight
+- **Pre-fill for all flows:** Fresh generation, history repeat, and favorite repeat all call fetchLastSetData
+- **22 unit tests added:** Detection heuristic (11 cases), buildInitialSets (5 cases), summarizeSets (6 cases) — all passing
+- **QA spike ticket created (#42):** Researched AI-led QA practices (Playwright Test Agents, Claude Code headless CI, MCP), wrote comprehensive spike PRD
+
+#### What Came Up (Unexpected)
+- All implementation changes were reverted during user commit batch — code was fully functional (tsc + build + tests passing) but didn't survive the commit. Session transcript serves as blueprint for re-application.
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| No exercise_definition_id on set_logs table | Join chain exercise_set_logs -> exercises.exercise_id -> exercise_definitions provides this — avoids sync risk |
+| weight as NUMERIC not TEXT | Enables future math (volume = weight x reps). Legacy weight_logged TEXT stays for backward compat |
+| Detection heuristic for per-set inputs | Only exercises with numeric reps + standard sets + not timed/circuit get per-set rows |
+| Write to BOTH exercise_set_logs AND exercises.weight_logged | Summary string in legacy column means existing code still works |
+| Playwright E2E as recommended QA tier | Catches integration bugs across 12+ file surface area; Test Agents + MCP align with Claude Code workflow |
+
+#### Files Changed (implemented then reverted)
+| File | Action |
+|------|--------|
+| `supabase/migrations/00028_exercise_set_logs.sql` | Created — new table + RLS |
+| `supabase/migrations/00029_get_last_set_data_rpc.sql` | Created — pre-fill RPC |
+| `src/types/workout.ts` | Modified — SetLog, ExerciseSetData, extended Exercise/WorkoutNotes/LoggedExercise |
+| `src/lib/workout-api.ts` | Modified — completeWorkoutSession (set logs), fetchLastSetData, exerciseDefinitionId injection |
+| `src/components/workout/ActiveExerciseCard.tsx` | Rewritten — per-set input rows |
+| `src/components/workout/ActiveExerciseCard.test.tsx` | Created — 22 unit tests |
+| `src/pages/WorkoutScreen.tsx` | Modified — setLogData state, handleSetLog |
+| `src/components/workout/SectionRenderer.tsx` | Modified — forward onSetLog prop |
+| `src/components/workout/StructureCards.tsx` | Modified — forward onSetLog in SupersetCard |
+| `src/components/workout/SupersetRenderer.tsx` | Modified — forward onSetLog |
+| `src/pages/SessionDetailScreen.tsx` | Modified — per-set breakdown display |
+| `src/lib/home-data.ts` | Modified — fetch set logs in fetchWorkoutDetail |
+| `src/hooks/useWorkoutSession.ts` | Modified — pass setLogData, fetchLastSetData for repeats |
+| `src/hooks/useWorkoutGeneration.ts` | Modified — injectLastSetData after generation |
+
+#### Status
+- Implementation was complete and all checks passed (tsc, build, lint, 48/51 tests — 3 pre-existing failures)
+- Code was reverted during commit batch — needs re-application next session
+- GitHub Issue #42 (QA spike) created and on project board
+
+---
 
 ### Session: 2026-04-23 - Smart Training System: PRD Ticket Suite
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -366,8 +366,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Actions
   const signOut = useCallback(async () => {
-    await supabase.auth.signOut();
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      logger.auth.warn('signOut API call failed, clearing local session', { error });
+    }
+    // Always clear local state, even if the server-side revocation fails
     clearStayLoggedIn();
+    setState({
+      status: 'unauthenticated',
+      user: null,
+      profile: null,
+      locations: [],
+      error: null,
+    });
   }, []);
 
   const updateProfile = useCallback(async (updates: Partial<Profile>) => {


### PR DESCRIPTION
## Summary
- `signOut()` relied on `supabase.auth.signOut()` succeeding for the `SIGNED_OUT` event to fire — if the API call failed in production, nothing happened
- Now catches server-side revocation errors and always clears local auth state, ensuring logout works even when the Supabase endpoint is unreachable

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Sign in, go to Settings, tap Sign Out → confirm → should redirect to /welcome
- [ ] Verify normal sign-out still works when Supabase is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)