### PR TITLE
Fix sign-out hanging on Vercel

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -366,12 +366,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Actions
   const signOut = useCallback(async () => {
-    try {
-      await supabase.auth.signOut();
-    } catch (error) {
-      logger.auth.warn('signOut API call failed, clearing local session', { error });
-    }
-    // Always clear local state, even if the server-side revocation fails
+    // Clear local state FIRST — supabase.auth.signOut() can hang on Vercel
+    // (promise never settles), so we can't depend on it completing
     clearStayLoggedIn();
     setState({
       status: 'unauthenticated',
@@ -379,6 +375,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       profile: null,
       locations: [],
       error: null,
+    });
+    // Best-effort server-side session revocation (fire-and-forget)
+    supabase.auth.signOut().catch((error) => {
+      logger.auth.warn('signOut server revocation failed', { error });
     });
   }, []);
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- `supabase.auth.signOut()` hangs on Vercel (promise never settles), so the state-clearing code after `await` never executes
- Fix: clear local auth state **first**, then fire server-side revocation as best-effort fire-and-forget
- User sees instant logout regardless of Supabase API behavior

## Test plan
- [ ] Open Vercel preview deployment
- [ ] Sign in, go to Settings, tap Sign Out → confirm
- [ ] Verify you're redirected to the login screen immediately
- [ ] Verify you can sign back in normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)