### PR TITLE
Add Claude Code hooks: lint, branch guard, UI nudge

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Branch Guard Hook (PreToolUse — Edit/Write)
+# Warns (non-blocking) if you're about to edit src/ files while on main.
+
+set -e
+
+INPUT=$(cat)
+
+source "$(dirname "$0")/hook-utils.sh"
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# No file path — skip
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only care about src/ edits (not docs, config, etc.)
+if [[ "$FILE_PATH" != *"/src/"* ]]; then
+  exit 0
+fi
+
+# Check current branch
+BRANCH=$(cd "$CLAUDE_PROJECT_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  cat >&2 << 'EOF'
+WARNING: You're editing src/ files on main. Create a feature branch first:
+  git checkout -b feature/your-feature
+EOF
+  hook_log "WARN editing src/ on main: $FILE_PATH"
+  # Non-blocking — just a warning. Change to exit 2 to hard-block.
+  exit 0
+fi
+
+hook_log "PASS (branch: $BRANCH)"
+exit 0

--- a/.claude/hooks/design-system-lint.sh
+++ b/.claude/hooks/design-system-lint.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Design System Lint Hook (PostToolUse — Edit/Write)
+# Fast grep-based check on the file just edited. No Node, no build.
+# Catches mechanical violations that are ALWAYS wrong in component files.
+
+set -e
+
+INPUT=$(cat)
+
+source "$(dirname "$0")/hook-utils.sh"
+
+# Extract the file path from the tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# No file path — skip
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only check src/ files (components, pages, hooks, etc.)
+if [[ "$FILE_PATH" != *"/src/"* ]]; then
+  exit 0
+fi
+
+# Skip files that legitimately use primitives/hex
+BASENAME=$(basename "$FILE_PATH")
+case "$BASENAME" in
+  index.css|utils.ts|database.ts|*.test.ts|*.test.tsx|*.d.ts)
+    exit 0
+    ;;
+esac
+
+# Only check .tsx, .ts, .css files
+case "$FILE_PATH" in
+  *.tsx|*.ts|*.css) ;;
+  *) exit 0 ;;
+esac
+
+# Check if file exists
+if [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+WARNINGS=""
+
+# 1. Hex colors in style-related contexts (skip comments)
+HEX_HITS=$(grep -n 'color\|background\|fill\|stroke\|border\|shadow' "$FILE_PATH" 2>/dev/null \
+  | grep -v '^\s*//' \
+  | grep -v '^\s*\*' \
+  | grep -oE '#[0-9A-Fa-f]{3,8}' \
+  | head -5) || true
+if [ -n "$HEX_HITS" ]; then
+  WARNINGS+="  - Hex color(s) found: use semantic tokens instead"$'\n'
+fi
+
+# 2. Primitive tokens (--color-orange-*, --color-blue-*, etc.)
+PRIM_HITS=$(grep -n 'var(--color-\(orange\|blue\|green\|red\|purple\|neutral\)-' "$FILE_PATH" 2>/dev/null \
+  | grep -v '^\s*//' \
+  | grep -v '^\s*\*' \
+  | head -5) || true
+if [ -n "$PRIM_HITS" ]; then
+  WARNINGS+="  - Primitive token(s) found: use --surface-*, --text-*, --border-* instead"$'\n'
+fi
+
+# 3. border-radius (CLEAR uses chamfered corners)
+BR_HITS=$(grep -n 'border-\?[Rr]adius' "$FILE_PATH" 2>/dev/null \
+  | grep -v '^\s*//' \
+  | grep -v '^\s*\*' \
+  | grep -v 'border-radius: 0' \
+  | grep -v '// ok' \
+  | head -3) || true
+if [ -n "$BR_HITS" ]; then
+  WARNINGS+="  - border-radius found: use ChamferedFrame or corner-cut class"$'\n'
+fi
+
+# 4. lucide-react imports
+LUCIDE_HITS=$(grep -n "from ['\"]lucide-react['\"]" "$FILE_PATH" 2>/dev/null | head -1) || true
+if [ -n "$LUCIDE_HITS" ]; then
+  WARNINGS+="  - lucide-react import: use src/components/icons.tsx instead"$'\n'
+fi
+
+# 5. !important (bandaid)
+IMPORTANT_HITS=$(grep -n '!important' "$FILE_PATH" 2>/dev/null \
+  | grep -v '^\s*//' \
+  | grep -v '^\s*\*' \
+  | head -3) || true
+if [ -n "$IMPORTANT_HITS" ]; then
+  WARNINGS+="  - !important found: fix specificity instead"$'\n'
+fi
+
+# Report (non-blocking — exit 0 always, just print warnings)
+if [ -n "$WARNINGS" ]; then
+  echo "Design system lint ($BASENAME):" >&2
+  echo "$WARNINGS" >&2
+  hook_log "WARN $BASENAME: $(echo "$WARNINGS" | tr '\n' ' ')"
+else
+  hook_log "PASS $BASENAME"
+fi
+
+exit 0

--- a/.claude/hooks/git-safety-check.sh
+++ b/.claude/hooks/git-safety-check.sh
@@ -7,6 +7,8 @@ set -e
 # Read JSON input from stdin
 INPUT=$(cat)
 
+source "$(dirname "$0")/hook-utils.sh"
+
 # Extract the command being run
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
@@ -149,4 +151,5 @@ fi
 # fi
 
 # All checks passed
+hook_log "PASS"
 exit 0

--- a/.claude/hooks/hook-debug.sh
+++ b/.claude/hooks/hook-debug.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Hook Debug Tool
+# Usage:
+#   .claude/hooks/hook-debug.sh          — show status + recent logs
+#   .claude/hooks/hook-debug.sh test     — run all hooks with test inputs
+#   .claude/hooks/hook-debug.sh disable  — create kill switch (disable all hooks)
+#   .claude/hooks/hook-debug.sh enable   — remove kill switch (re-enable all hooks)
+#   .claude/hooks/hook-debug.sh disable <name> — disable one hook
+#   .claude/hooks/hook-debug.sh enable <name>  — re-enable one hook
+
+set -e
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$HOOK_DIR/logs"
+KILL_SWITCH="$HOOK_DIR/.disabled"
+
+case "${1:-status}" in
+
+  status)
+    echo "=== Hook Status ==="
+    echo ""
+
+    # Kill switch
+    if [ -f "$KILL_SWITCH" ]; then
+      echo "KILL SWITCH: ACTIVE (all hooks disabled)"
+      echo "  Remove with: $0 enable"
+    else
+      echo "KILL SWITCH: off (hooks enabled)"
+    fi
+    echo ""
+
+    # Per-hook status
+    echo "=== Individual Hooks ==="
+    for hook in "$HOOK_DIR"/*.sh; do
+      name=$(basename "$hook" .sh)
+      # Skip utility scripts
+      case "$name" in hook-utils|hook-debug) continue ;; esac
+
+      if [ -f "$HOOK_DIR/.disabled-$name" ]; then
+        status="DISABLED"
+      else
+        status="enabled"
+      fi
+      printf "  %-25s %s\n" "$name" "$status"
+    done
+    echo ""
+
+    # Recent logs
+    echo "=== Recent Logs ==="
+    if [ -d "$LOG_DIR" ]; then
+      for log in "$LOG_DIR"/*.log; do
+        [ -f "$log" ] || continue
+        name=$(basename "$log" .log)
+        echo ""
+        echo "--- $name (last 10) ---"
+        tail -10 "$log" 2>/dev/null || echo "  (empty)"
+      done
+    else
+      echo "  No logs yet (logs appear after first hook run)"
+    fi
+    ;;
+
+  test)
+    echo "=== Testing Hooks ==="
+    echo ""
+
+    # Test branch-guard (should warn — we're on main editing src/)
+    echo "--- branch-guard (editing src/ on main) ---"
+    echo '{"tool_input":{"file_path":"'"$HOOK_DIR"'/../../src/components/Test.tsx"}}' \
+      | CLAUDE_PROJECT_DIR="$HOOK_DIR/../.." "$HOOK_DIR/branch-guard.sh" 2>&1
+    echo "  exit: $?"
+    echo ""
+
+    # Test branch-guard (editing docs — should be silent)
+    echo "--- branch-guard (editing docs/ — should be silent) ---"
+    echo '{"tool_input":{"file_path":"'"$HOOK_DIR"'/../../docs/test.md"}}' \
+      | CLAUDE_PROJECT_DIR="$HOOK_DIR/../.." "$HOOK_DIR/branch-guard.sh" 2>&1
+    echo "  exit: $?"
+    echo ""
+
+    # Test design-system-lint (needs a real file — just check it doesn't crash)
+    echo "--- design-system-lint (index.css — should skip) ---"
+    echo '{"tool_input":{"file_path":"'"$HOOK_DIR"'/../../src/index.css"}}' \
+      | "$HOOK_DIR/design-system-lint.sh" 2>&1
+    echo "  exit: $?"
+    echo ""
+
+    # Test ui-preflight-nudge (UI keyword)
+    echo "--- ui-preflight-nudge ('update the button component') ---"
+    echo '{"prompt":"update the button component"}' \
+      | "$HOOK_DIR/ui-preflight-nudge.sh" 2>&1
+    echo "  exit: $?"
+    echo ""
+
+    # Test ui-preflight-nudge (non-UI)
+    echo "--- ui-preflight-nudge ('fix auth bug' — should be silent) ---"
+    echo '{"prompt":"fix auth bug"}' \
+      | "$HOOK_DIR/ui-preflight-nudge.sh" 2>&1
+    echo "  exit: $?"
+    echo ""
+
+    # Test git-safety (safe command)
+    echo "--- git-safety ('git status' — should pass) ---"
+    echo '{"tool_input":{"command":"git status"}}' \
+      | CLAUDE_PROJECT_DIR="$HOOK_DIR/../.." "$HOOK_DIR/git-safety-check.sh" 2>&1
+    echo "  exit: $?"
+    echo ""
+
+    # Test git-safety (dangerous command)
+    echo "--- git-safety ('git push origin main' — should BLOCK) ---"
+    echo '{"tool_input":{"command":"git push origin main"}}' \
+      | CLAUDE_PROJECT_DIR="$HOOK_DIR/../.." "$HOOK_DIR/git-safety-check.sh" 2>&1
+    echo "  exit: $?"
+    echo ""
+
+    echo "=== All tests complete ==="
+    ;;
+
+  disable)
+    if [ -n "$2" ]; then
+      touch "$HOOK_DIR/.disabled-$2"
+      echo "Disabled hook: $2"
+      echo "Re-enable with: $0 enable $2"
+    else
+      touch "$KILL_SWITCH"
+      echo "Kill switch ACTIVE — all custom hooks disabled."
+      echo "Re-enable with: $0 enable"
+    fi
+    ;;
+
+  enable)
+    if [ -n "$2" ]; then
+      rm -f "$HOOK_DIR/.disabled-$2"
+      echo "Re-enabled hook: $2"
+    else
+      rm -f "$KILL_SWITCH"
+      echo "Kill switch removed — all hooks re-enabled."
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 [status|test|disable|enable] [hook-name]"
+    exit 1
+    ;;
+esac

--- a/.claude/hooks/hook-utils.sh
+++ b/.claude/hooks/hook-utils.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Shared utilities for all Claude Code hooks.
+# Source this at the top of every hook: source "$(dirname "$0")/hook-utils.sh"
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_NAME="$(basename "${BASH_SOURCE[1]}" .sh)"
+HOOK_LOG_DIR="$HOOK_DIR/logs"
+KILL_SWITCH="$HOOK_DIR/.disabled"
+
+# --- Kill switch ---
+# Create .claude/hooks/.disabled to silence ALL custom hooks instantly.
+# Remove it to re-enable. Works from any terminal, no Claude needed.
+if [ -f "$KILL_SWITCH" ]; then
+  exit 0
+fi
+
+# --- Per-hook disable ---
+# Create .claude/hooks/.disabled-<hook-name> to silence one hook.
+# e.g. touch .claude/hooks/.disabled-design-system-lint
+if [ -f "$HOOK_DIR/.disabled-$HOOK_NAME" ]; then
+  exit 0
+fi
+
+# --- Logging ---
+mkdir -p "$HOOK_LOG_DIR"
+HOOK_LOG="$HOOK_LOG_DIR/$HOOK_NAME.log"
+
+# Keep log under 500 lines (rotate on each run)
+if [ -f "$HOOK_LOG" ] && [ "$(wc -l < "$HOOK_LOG" 2>/dev/null | tr -d ' ')" -gt 500 ]; then
+  tail -200 "$HOOK_LOG" > "$HOOK_LOG.tmp" && mv "$HOOK_LOG.tmp" "$HOOK_LOG"
+fi
+
+hook_log() {
+  echo "[$(date '+%H:%M:%S')] $*" >> "$HOOK_LOG"
+}
+
+# Log start
+hook_log "START"
+
+# --- Error trap ---
+# If the hook crashes, log the error and exit 0 (never block on a bug)
+trap 'hook_log "CRASHED (line $LINENO, exit $?)"; exit 0' ERR

--- a/.claude/hooks/session-start-check.sh
+++ b/.claude/hooks/session-start-check.sh
@@ -7,6 +7,8 @@ set -e
 
 cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
 
+source "$(dirname "$0")/hook-utils.sh"
+
 OUTPUT=""
 
 # --- Check current branch and uncommitted changes ---

--- a/.claude/hooks/ui-preflight-nudge.sh
+++ b/.claude/hooks/ui-preflight-nudge.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# UI Pre-flight Nudge (user-prompt-submit)
+# Reminds about mandatory pre-flight when prompt looks UI-related.
+
+set -e
+
+INPUT=$(cat)
+
+source "$(dirname "$0")/hook-utils.sh"
+
+# Extract the user's prompt
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' | tr '[:upper:]' '[:lower:]')
+
+if [ -z "$PROMPT" ]; then
+  exit 0
+fi
+
+# Check for UI-related keywords
+if echo "$PROMPT" | grep -qE 'component|style|layout|page |pages|css|button|modal|card |cards|tab |tabs|input|form |spacing|padding|margin|chamfer|gallery|ui |redesign|visual|icon |icons'; then
+  # Don't nudge if the prompt already mentions pre-flight or if it's a question
+  if echo "$PROMPT" | grep -qE 'pre-?flight|preflight|inventory|what is|how do|explain|why'; then
+    exit 0
+  fi
+  echo "Reminder: UI pre-flight is mandatory before building. Inventory existing components + check tokens first." >&2
+  hook_log "NUDGE fired"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,39 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/branch-guard.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/design-system-lint.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/ui-preflight-nudge.sh",
+            "timeout": 3
+          }
+        ]
       }
     ]
   },

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ dist-ssr
 # Supabase temp files
 supabase/.temp/
 
+# Hook runtime files
+.claude/hooks/.disabled*
+.claude/hooks/logs/
+
 # macOS artifacts
 *.textClipping
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-04-25 (23rd session)
+**Last Session:** 2026-05-21 (24th session)
 
 ---
 
@@ -15,12 +15,55 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ## Quick Status
 **Current Phase:** Smart Training System — Phase 1 deployed
 **Current Task:** None
-**Last Completed:** Integration gap audit — timeouts, silent failures, auth hardening
+**Last Completed:** Claude Code hooks infrastructure — automated design system checks
 **Blocking Issues:** 37 token-lint violations pending
 
 ---
 
 ## Session Entries
+
+### Session: 2026-05-21 - Claude Code Hooks Infrastructure
+
+**Duration:** ~30 min
+**Mode:** Claude Code
+**Branch:** `feature/claude-hooks-infrastructure`
+
+#### What Got Done
+- **Discussed hooks vs skills tradeoffs** — evaluated which manual skills could become automated hooks, identified pitfalls (speed tax, false confidence, invisible failures, scope creep)
+- **Design system lint hook** — PostToolUse grep-based check on Edit/Write for hex colors, primitive tokens, border-radius, lucide-react, !important in src/ files. No Node, <200ms.
+- **Branch guard hook** — PreToolUse warning when editing src/ files while on main. Catches the problem at edit time, not push time.
+- **UI pre-flight nudge hook** — UserPromptSubmit keyword detection reminds about mandatory component.md pre-flight for UI-related prompts.
+- **Shared hook infrastructure** — hook-utils.sh provides kill switch (global + per-hook), timestamped logging with auto-rotation, and error trap (crashes log and exit 0, never block).
+- **Debug/test tooling** — hook-debug.sh with status, test, disable, enable commands for quick troubleshooting.
+- **Wired existing hooks** — git-safety-check and session-start-check now also use shared utils (kill switch, logging, error trap).
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| All new hooks non-blocking (exit 0) | Warnings only — can observe behavior before promoting to hard gates |
+| Pure grep, no Node for lint hook | Speed matters on every file edit; full token-lint.ts stays as manual pre-PR check |
+| Kill switch via file touch | Works from any terminal without Claude — critical escape hatch |
+| Skipped build-on-commit hook | Too slow, PR workflow already catches build failures |
+| Skipped branch guard as hard block | Redundant with git-safety push block; warning is sufficient |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `.claude/hooks/design-system-lint.sh` | Created — PostToolUse design system grep lint |
+| `.claude/hooks/branch-guard.sh` | Created — PreToolUse main branch warning |
+| `.claude/hooks/ui-preflight-nudge.sh` | Created — UserPromptSubmit UI pre-flight reminder |
+| `.claude/hooks/hook-utils.sh` | Created — Shared kill switch, logging, error trap |
+| `.claude/hooks/hook-debug.sh` | Created — Debug/test/disable/enable CLI tool |
+| `.claude/hooks/git-safety-check.sh` | Modified — Wired into shared utils |
+| `.claude/hooks/session-start-check.sh` | Modified — Wired into shared utils |
+| `.claude/settings.json` | Modified — Registered 3 new hooks |
+| `.gitignore` | Modified — Ignore hook runtime files (.disabled*, logs/) |
+
+#### Status
+- Build: N/A (no src/ changes)
+- 1 commit on feature branch, ready for PR
+
+---
 
 ### Session: 2026-04-25 - Integration Gap Audit & Fixes
 


### PR DESCRIPTION
## Summary
- Three new automated hooks: design-system lint (PostToolUse), branch guard (PreToolUse), UI pre-flight nudge (UserPromptSubmit)
- Shared infrastructure: kill switch, per-hook disable, timestamped logging, error trap
- Debug CLI: `hook-debug.sh` with status/test/disable/enable commands
- All new hooks are non-blocking (warnings only) — can promote to hard gates after observation

## Test plan
- [ ] Start a new Claude Code session — verify session-start hook still works
- [ ] Edit a src/ file on main — verify branch guard warning appears
- [ ] Edit a file with hex colors — verify lint warning appears
- [ ] Send a UI-related prompt — verify pre-flight nudge appears
- [ ] Run `.claude/hooks/hook-debug.sh test` — all hooks pass
- [ ] Run `.claude/hooks/hook-debug.sh disable` then verify hooks are silent
- [ ] Run `.claude/hooks/hook-debug.sh enable` to re-enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)