### PR TITLE
Fix QueryClientProvider ordering crash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { Toaster } from "@/components/ui/sonner";
 import { lazy, Suspense } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const ReactQueryDevtools = lazy(() =>
   import("@tanstack/react-query-devtools").then((m) => ({
@@ -32,75 +31,62 @@ import { ComponentGallery } from "@/pages/ComponentGallery";
 import { TestWorkoutScreen } from "@/pages/TestWorkoutScreen";
 import NotFound from "./pages/NotFound";
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000,
-      gcTime: 10 * 60 * 1000,
-      retry: 1,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
-
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <>
-      <Toaster />
-      <AnimatedBackground />
-      <BrowserRouter>
-        <HomeDataProvider>
-          <WorkoutFlowProvider>
-            <Routes>
-              {/* Public-only routes (redirect if authenticated) */}
-              <Route element={<PublicOnlyRoute />}>
-                <Route path="/welcome" element={<WelcomeScreen />} />
-                <Route path="/sign-in" element={<SignInScreen />} />
-                <Route path="/create-account" element={<CreateAccountScreen />} />
-                <Route path="/forgot-password" element={<ForgotPasswordScreen />} />
-              </Route>
+  <>
+    <Toaster />
+    <AnimatedBackground />
+    <BrowserRouter>
+      <HomeDataProvider>
+        <WorkoutFlowProvider>
+          <Routes>
+            {/* Public-only routes (redirect if authenticated) */}
+            <Route element={<PublicOnlyRoute />}>
+              <Route path="/welcome" element={<WelcomeScreen />} />
+              <Route path="/sign-in" element={<SignInScreen />} />
+              <Route path="/create-account" element={<CreateAccountScreen />} />
+              <Route path="/forgot-password" element={<ForgotPasswordScreen />} />
+            </Route>
 
-              {/* Reset password — unguarded (user arrives authenticated via recovery link) */}
-              <Route path="/reset-password" element={<ResetPasswordScreen />} />
+            {/* Reset password — unguarded (user arrives authenticated via recovery link) */}
+            <Route path="/reset-password" element={<ResetPasswordScreen />} />
 
-              {/* Onboarding route (must be auth'd but NOT onboarded) */}
-              <Route element={<OnboardingRoute />}>
-                <Route path="/onboarding" element={<OnboardingScreen />} />
-              </Route>
+            {/* Onboarding route (must be auth'd but NOT onboarded) */}
+            <Route element={<OnboardingRoute />}>
+              <Route path="/onboarding" element={<OnboardingScreen />} />
+            </Route>
 
-              {/* Protected routes (must be auth'd + onboarded) */}
-              <Route element={<ProtectedRoute />}>
-                <Route path="/" element={<HomeScreen />} />
-                <Route path="/generate" element={<GenerationScreen />} />
-                <Route path="/review" element={<ReviewScreen />} />
-                <Route path="/workout" element={<WorkoutScreen />} />
-                <Route path="/summary" element={<SummaryScreen />} />
-                <Route path="/history" element={<HistoryScreen />} />
-                <Route path="/history/:id" element={<SessionDetailScreen />} />
-                <Route path="/settings" element={<SettingsScreen />} />
-              </Route>
+            {/* Protected routes (must be auth'd + onboarded) */}
+            <Route element={<ProtectedRoute />}>
+              <Route path="/" element={<HomeScreen />} />
+              <Route path="/generate" element={<GenerationScreen />} />
+              <Route path="/review" element={<ReviewScreen />} />
+              <Route path="/workout" element={<WorkoutScreen />} />
+              <Route path="/summary" element={<SummaryScreen />} />
+              <Route path="/history" element={<HistoryScreen />} />
+              <Route path="/history/:id" element={<SessionDetailScreen />} />
+              <Route path="/settings" element={<SettingsScreen />} />
+            </Route>
 
-              {/* Dev routes — only available in development */}
-              {import.meta.env.DEV && (
-                <>
-                  <Route path="/dev/gallery" element={<ComponentGallery />} />
-                  <Route path="/dev/test-workout" element={<TestWorkoutScreen />} />
-                </>
-              )}
+            {/* Dev routes — only available in development */}
+            {import.meta.env.DEV && (
+              <>
+                <Route path="/dev/gallery" element={<ComponentGallery />} />
+                <Route path="/dev/test-workout" element={<TestWorkoutScreen />} />
+              </>
+            )}
 
-              {/* Catch-all */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </WorkoutFlowProvider>
-        </HomeDataProvider>
-      </BrowserRouter>
-    </>
+            {/* Catch-all */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </WorkoutFlowProvider>
+      </HomeDataProvider>
+    </BrowserRouter>
     {import.meta.env.DEV && (
       <Suspense fallback={null}>
         <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
       </Suspense>
     )}
-  </QueryClientProvider>
+  </>
 );
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "react-error-boundary";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.tsx";
 import { AuthProvider } from "./contexts/AuthContext";
 import { AppErrorFallback } from "./components/AppErrorFallback";
@@ -9,10 +10,23 @@ import "./transitions.css";
 
 initTheme();
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary FallbackComponent={AppErrorFallback}>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </QueryClientProvider>
   </ErrorBoundary>
 );


### PR DESCRIPTION
## Summary
- **Bug:** App crashed on load with "No QueryClient set, use QueryClientProvider to set one"
- **Cause:** `AuthProvider` (which calls `useQueryClient()`) was rendered outside `QueryClientProvider` in `main.tsx`, while `QueryClientProvider` lived inside `App.tsx`
- **Fix:** Moved `QueryClient` creation and `QueryClientProvider` up to `main.tsx` so it wraps `AuthProvider`. Removed the duplicate from `App.tsx`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Local dev server loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)