### PR TITLE
Session 27: assembly reference, skill fixes, Strava analysis

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -167,6 +167,7 @@ Agents are specialized AI personas. Invoke via Task tool with matching `subagent
 
 | Skill | Trigger | What It Does |
 |-------|---------|--------------|
+| [`assembly-reference`](skills/assembly-reference.md) | Any UI work | Token lookup, spacing recipes, composition patterns, atmosphere rules |
 | [`component`](skills/component.md) | Creating/refactoring UI | Enforces design system, component structure |
 | [`chamfered-component`](skills/chamfered-component.md) | Building chamfered frame components | ChamferedFrame + LeftColumn pattern |
 | [`gallery-add`](skills/gallery-add.md) | After creating a component | Add visual test case to gallery |
@@ -334,8 +335,9 @@ debug.md → [fix] → token-check.md (if UI) → pr-workflow.md
 │   ├── component.md       ← UI components
 │   ├── chamfered-component.md
 │   ├── gallery-add.md
-│   ├── ui-rules.md            ← Spacing, typography, visual hierarchy, cards, states
-│   ├── token-decision-tree.md ← Which token to use for what
+│   ├── assembly-reference.md   ← START HERE: composition recipes, token cheat sheet, spacing
+│   ├── ui-rules.md            ← Full rules: spacing, typography, visual hierarchy, cards, states
+│   ├── token-decision-tree.md ← Edge cases: which token to use for what
 │   ├── anti-patterns.md       ← Common LLM mistakes to avoid
 │   ├── token-check.md
 │   ├── token-audit.md

--- a/.claude/skills/assembly-reference.md
+++ b/.claude/skills/assembly-reference.md
@@ -1,0 +1,309 @@
+---
+name: assembly-reference
+description: Quick-reference for building UI — composition recipes, token lookup, spacing, atmosphere
+trigger: Before any UI work, alongside component.md pre-flight
+category: design-system
+---
+
+# Assembly Reference
+
+The single starting point for building UI in CLEAR. Recipes first, details in linked docs.
+
+**When to read what:**
+- **This file** — how to assemble common patterns (tokens, classes, spacing, atmosphere)
+- `component.md` — pre-flight checklist before building (mandatory)
+- `token-decision-tree.md` — edge cases when this file doesn't cover your token need
+- `ui-rules.md` — full rules (typography scale, spacing scale, state coverage, visual hierarchy)
+- `design-philosophy.md` — judgment calls, the "why" layer
+- `anti-patterns.md` — what NOT to do
+
+---
+
+## Token Cheat Sheet (by context)
+
+### Card
+
+```
+surface:       --surface-card
+surface-accent: --surface-card-accent        (for emphasized sub-areas)
+border:        --border-card
+label:         --text-card-label             (section labels like "INTENSITY LEVEL")
+title:         --text-header                 (values like "UPPER BODY")
+body:          --text-paragraph              (descriptions, explanations)
+muted:         --text-muted                  (secondary info, subtitles)
+```
+
+### Form Input (Input, Textarea)
+
+```
+surface:       --surface-input               (default)
+               --surface-input-active        (focused)
+               --surface-input-disabled      (disabled)
+border:        --border-input / --border-input-active / --border-input-disabled
+text:          --text-input / --text-input-disabled
+placeholder:   --text-input-placeholder
+icon:          --icon-input / --icon-input-disabled
+```
+
+### CTA Button
+
+```
+surface:       --surface-cta-primary         (default)
+               --surface-cta-primary-hover   (hover)
+               --surface-cta-primary-disabled (disabled)
+border:        --border-cta / --border-cta-hover
+text:          --text-cta / --text-cta-hover
+destructive:   --text-cta-destructive / --text-cta-destructive-hover
+```
+
+### Radio Button / Selection
+
+```
+surface:       --surface-radio-selected / --surface-radio-unselect
+border:        --border-radio-select / --border-radio-unselected
+text:          --text-radio-text-select / --text-radio-text-unselected
+icon:          --icon-radio-selected / --icon-radio-unselected
+```
+
+### General Text
+
+```
+headers:       --text-header                 (page titles, card values)
+paragraphs:    --text-paragraph              (body text)
+muted:         --text-muted                  (secondary, subtle)
+disabled:      --text-disabled               (inactive elements)
+```
+
+### Interactive Icons
+
+```
+cta:           --icon-cta                    (tappable icons, chevrons)
+badge:         --icon-badge                  (status indicators)
+```
+
+---
+
+## Spacing Recipes
+
+| Context | Token | px (approx) |
+|---------|-------|-------------|
+| Page top padding | `spacing-600` | 24 |
+| Gap between cards in a list | `spacing-600` | 24 |
+| Padding inside Card (`padding="md"`) | `spacing-400` | 16 |
+| Padding inside Card (`padding="lg"`) | `spacing-600` | 24 |
+| Card label to its content | `spacing-100` to `spacing-200` | 4–8 |
+| Card label `marginBottom` (with content below) | `spacing-200` to `spacing-300` | 8–12 |
+| Gap between elements inside a card | `spacing-200` to `spacing-300` | 8–12 |
+| Gap between form fields | `spacing-400` | 16 |
+| Section divider padding-top | `spacing-400` | 16 |
+| Between icon and text (inline) | `spacing-200` | 8 |
+
+**Rule of thumb:** `spacing-600` between major sections, `spacing-400` inside sections, `spacing-200` between sibling elements.
+
+---
+
+## Composition Recipes
+
+### 1. Card with Label + Value
+
+The most common pattern. Used in GenerationScreen (Recommended Focus, Intensity, Duration, Notes).
+
+```tsx
+<Card cornerSize="md" padding="md">
+  <span
+    className="text-label-xs"
+    style={{
+      color: 'var(--text-card-label)',
+      textTransform: 'uppercase',
+      letterSpacing: '0.1em',
+      display: 'block',
+      marginBottom: 'var(--spacing-200)',
+    }}
+  >
+    Section Label
+  </span>
+  <span
+    className="text-heading-h4"
+    style={{ color: 'var(--text-header)', display: 'block' }}
+  >
+    Value
+  </span>
+  {/* Optional subtitle */}
+  <span className="text-paragraph-sm" style={{ color: 'var(--text-muted)' }}>
+    Supporting text
+  </span>
+</Card>
+```
+
+### 2. Form Field Card (Input or Textarea inside a Card)
+
+```tsx
+<Card cornerSize="md" padding="md">
+  <label
+    className="text-label-xs"
+    style={{
+      color: 'var(--text-card-label)',
+      textTransform: 'uppercase',
+      letterSpacing: '0.1em',
+      marginBottom: 'var(--spacing-300)',
+      display: 'block',
+    }}
+  >
+    Field Label
+  </label>
+  <Input placeholder="Placeholder text" />
+  {/* or <Textarea placeholder="..." /> */}
+</Card>
+```
+
+### 3. Accordion Card (Location selector pattern)
+
+```tsx
+<Card cornerSize="md" padding="none">
+  <button
+    onClick={toggle}
+    style={{
+      width: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: 'var(--spacing-400)',
+      textAlign: 'left',
+    }}
+  >
+    <div>
+      <span className="text-label-xs"
+        style={{ textTransform: 'uppercase', letterSpacing: '0.1em',
+                 display: 'block', marginBottom: 'var(--spacing-100)',
+                 color: 'var(--text-card-label)' }}>
+        Label
+      </span>
+      <span className="text-heading-h5" style={{ color: 'var(--icon-cta)' }}>
+        {selectedValue}
+      </span>
+    </div>
+    <ChevronDown size={20} style={{ color: 'var(--icon-cta)' }} />
+  </button>
+  {isOpen && (
+    <div style={{ padding: '0 var(--spacing-400) var(--spacing-400)',
+                  display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>
+      {/* RadioButton options */}
+    </div>
+  )}
+</Card>
+```
+
+Note: `padding="none"` on Card because the button handles its own padding.
+
+### 4. Page Layout (standard screen)
+
+```tsx
+<AppLayout
+  header={<PageHeader left="back" onBack={handleBack} right="menu" onMenu={handleMenu} />}
+  footer={<CTAButton onClick={handleAction} size="lg" fullWidth>Action Label</CTAButton>}
+>
+  <div className="stagger-reveal" style={{
+    paddingTop: 'var(--spacing-600)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--spacing-600)',
+  }}>
+    {/* Cards go here */}
+  </div>
+</AppLayout>
+```
+
+- `grain-overlay` is applied by AppLayout automatically
+- `stagger-reveal` on the content wrapper for sequential card reveal
+- `spacing-600` gap between top-level cards
+
+### 5. Selection Group (RadioButtons in a Card)
+
+```tsx
+<Card cornerSize="md" padding="md">
+  <label className="text-label-xs"
+    style={{ textTransform: 'uppercase', letterSpacing: '0.1em',
+             marginBottom: 'var(--spacing-400)', display: 'block',
+             color: 'var(--text-card-label)' }}>
+    Choose One
+  </label>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>
+    <RadioButton selected={val === 'a'} onClick={() => set('a')} label="Option A" style={{ width: '100%' }} />
+    <RadioButton selected={val === 'b'} onClick={() => set('b')} label="Option B" style={{ width: '100%' }} />
+  </div>
+</Card>
+```
+
+For inline options (like duration presets), use `flexDirection: 'row'` with `flex: 1` on each.
+
+### 6. Confirmation Modal
+
+```tsx
+<ConfirmationModal
+  title="Action Title"
+  description="Are you sure you want to do this?"
+  confirmLabel="Confirm"
+  onConfirm={handleConfirm}
+  onCancel={handleCancel}
+/>
+```
+
+---
+
+## Atmosphere Rules
+
+Apply these by default — don't wait to be asked.
+
+| Surface | Class | Notes |
+|---------|-------|-------|
+| Page wrapper | `grain-overlay` | Applied by layout components (AppLayout, etc.) — don't add manually |
+| Card lists / content groups | `stagger-reveal` | Always on the parent div wrapping cards |
+| CTA buttons | `scanlines` | Built into CTAButton component |
+| Modals / toasts | `scanlines` | Built into ConfirmationModal, ChamferedToast |
+| PageHeader | `scanlines` | Built into PageHeader component |
+| Timer displays | `glow-emissive` | On text-time-lg elements |
+| Key data (streak, logo) | `glow-emissive` | Sparingly — only truly important numbers |
+| Accent bars / LeftColumn | `pulse-micro` | Structural elements only, never content |
+| Filter dropdowns | `scanlines` | Built into FilterDropdown |
+
+**Rule:** If you're building a new component and it's NOT in this table, don't add atmosphere. Ask first.
+
+---
+
+## State Coverage Checklist
+
+Every interactive element must have these states. Check before considering a component done.
+
+```
+[ ] default   — base appearance
+[ ] hover     — cursor over (subtle surface/border shift)
+[ ] selected  — currently active (if applicable — use green tokens)
+[ ] disabled  — non-interactive (muted surface, reduced opacity text)
+[ ] focus     — keyboard focus (if applicable — match hover or add border)
+```
+
+---
+
+## Typography Quick Ref
+
+| Class | Font | Use for |
+|-------|------|---------|
+| `text-heading-h1`–`h6` | Rajdhani bold | Page titles, card values, section headers. Add `uppercase`. |
+| `text-label-xs`–`xl` | Oxanium bold | Card labels, form labels, chip text, data readouts |
+| `text-paragraph-xs`–`xl` | Space Grotesk medium | Body text, descriptions, form content |
+| `text-cta-xs`–`lg` | Oxanium | Button labels. Uppercase + letter-spaced. |
+| `text-time-lg`/`xl` | Oxanium | Timer displays only |
+| `text-tab-xs`–`xl` | Oxanium | Tab labels |
+
+**Bold is default** — heading and label classes include `font-weight: bold`.
+**Uppercase is structural** — everything except paragraph text is uppercase.
+
+---
+
+## File Rename / Removal Checklist
+
+When renaming or removing any file in `src/`:
+
+1. `grep -r "filename" .claude/skills/` — update any skill references
+2. `grep -r "filename" .claude/agents/` — update any agent references
+3. `grep -r "ComponentName" .claude/skills/component.md` — update registry

--- a/.claude/skills/close-session.md
+++ b/.claude/skills/close-session.md
@@ -36,7 +36,7 @@ Track completed work for project history and continuity between agents. This ens
      a. **Component registry**: Run `npm run registry-check` — verify `component.md` registry matches actual components in `src/components/`
      b. **Token lint**: Run `npm run token-lint` — catch any new violations introduced this session
      c. **Doc drift**: If new components were added, check they're listed in `component.md` registry. If new tokens were added, check `token-decision-tree.md` covers them.
-     d. **Taste feedback**: If the user gave aesthetic corrections during this session (spacing adjustments, atmosphere changes, visual weight feedback), append entries to `memory/feedback_aesthetic.md`. Then review the file:
+     d. **Taste feedback**: If the user gave aesthetic corrections during this session (spacing adjustments, atmosphere changes, visual weight feedback), append entries to the auto-memory file `feedback_aesthetic.md` (in the persistent memory directory). Then review the file:
         - **Graduate**: Any pattern with 3+ entries → refine the matching rule in `ui-rules.md` or `anti-patterns.md`, then remove from the feedback file
         - **Consolidate**: Merge similar entries
         - **Prune**: Remove one-offs older than ~5 sessions that haven't repeated

--- a/.claude/skills/execute-plan.md
+++ b/.claude/skills/execute-plan.md
@@ -87,23 +87,20 @@ Also check:
 
 ### 5. Initialize Progress Tracking
 
-Use TodoWrite to create items for each task:
+Use TaskCreate to create items for each task:
 
 ```
-TodoWrite([
-  { content: "Task 1: [name from plan]", status: "pending", activeForm: "[active description]" },
-  { content: "Task 2: [name from plan]", status: "pending", activeForm: "[active description]" },
-  ...
-])
+TaskCreate({ title: "Task 1: [name from plan]", description: "[active description]" })
+TaskCreate({ title: "Task 2: [name from plan]", description: "[active description]" })
 ```
 
-All tasks start as `pending`.
+All tasks start as pending. Use TaskList to review progress.
 
 ### 6. Execute Tasks Sequentially
 
 For each task:
 
-1. **Mark in_progress** — Update TodoWrite
+1. **Mark in_progress** — TaskUpdate({ id: "...", status: "in_progress" })
 2. **Read the task's `**Do:**` section** — Understand what to do
 3. **Follow loaded skill steps** — If task type maps to a skill, follow it
 4. **Execute the work** — Make the changes, create files, etc.
@@ -140,7 +137,7 @@ Options:
 
 ### 8. Complete Task
 
-- Only mark `completed` in TodoWrite when:
+- Only mark `completed` via TaskUpdate when:
   - ALL acceptance criteria pass, OR
   - User explicitly skipped failing criteria
 
@@ -171,7 +168,7 @@ After all tasks complete:
 
 ## Progress Tracking Format
 
-TodoWrite items should look like:
+TaskList output should look like:
 
 ```
 [in_progress] Task 1: Create AuthContext
@@ -207,7 +204,7 @@ After completion:
 - [ ] Context files read
 - [ ] Tasks parsed with Do/Acceptance sections
 - [ ] Relevant skills pre-loaded based on task types
-- [ ] TodoWrite initialized with all tasks
+- [ ] TaskCreate used for all tasks
 - [ ] Each task executed with acceptance validation
 - [ ] Failures warned, user acknowledged skip/retry
 - [ ] Session logged via close-session skill

--- a/.claude/skills/inbox-workflow.md
+++ b/.claude/skills/inbox-workflow.md
@@ -85,7 +85,7 @@ Where should this go?
 5. **If user says yes to execute:**
    - Read `.claude/skills/execute-plan.md`
    - Follow the skill to execute the plan systematically
-   - Track progress with TodoWrite
+   - Track progress with TaskCreate/TaskUpdate
    - Validate acceptance criteria for each task
 
 ---

--- a/.claude/skills/pr-workflow.md
+++ b/.claude/skills/pr-workflow.md
@@ -124,6 +124,7 @@ Before creating a PR, verify:
 - [ ] **No hardcoded secrets** or API keys
 - [ ] **Changes are documented** if needed
 - [ ] **Commit messages are clear**
+- [ ] **Skill references intact** — if files were renamed/removed, `grep -r "filename" .claude/skills/ .claude/agents/` and update any stale references
 
 ---
 
@@ -202,8 +203,8 @@ gh pr merge --squash --delete-branch
 
 ## Related Skills
 
-- [code-reviewer agent](/.claude/agents/code-reviewer.md) — Automated code review
-- [close-session](/.claude/skills/close-session.md) — End of session workflow
+- [code-reviewer agent](.claude/agents/code-reviewer.md) — Automated code review
+- [close-session](.claude/skills/close-session.md) — End of session workflow
 
 ## Related Commands
 

--- a/docs/CATCHUP.md
+++ b/docs/CATCHUP.md
@@ -1,0 +1,297 @@
+# CATCHUP.md — Context Transfer for Claude.ai Planning Assistant
+
+> Generated: 2026-05-21
+> Last context the planning assistant has: ~Feb 27, 2026 (Workout Generation Prompt v3 draft)
+> Covers: Feb 27 → May 21, 2026 (Sessions 15–24)
+
+---
+
+## 1. Timeline Since Feb 27, 2026
+
+| Date | Session | Summary | Key Files | Architectural? |
+|------|---------|---------|-----------|----------------|
+| 2026-03-06 | 15 | Workout persistence (atomic RPC), favorites system, history/favorites tabs, scanline texture, custom icon system, ChamferedFrame fixes | `favorites-api.ts`, `workout-api.ts`, migrations 00023-00025, `icons.tsx` | **Yes** — `saved_workouts` + `saved_workout_completions` tables, atomic `save_generated_workout` RPC |
+| 2026-03-09 | 16 | Component consolidation — TabbedPanel compound component, 7 reusable extractions (EmptyState, ErrorState, LoadingSkeleton, WorkoutListItem, FavoriteListItem, WeekStreakDisplay, ConfirmationModal), shared tab geometry | `TabbedPanel.tsx`, `tab-geometry.ts`, `FilterDropdown.tsx`, `date-utils.ts` | No |
+| 2026-04-22 | 17 | Design token audit — eliminated all primitive token refs in components, 13 new semantic tokens, 17 unused tokens deleted, fabricated brown/cream tokens removed, `token-lint.ts` + `registry-check.ts` scripts | `index.css`, `token-lint.ts`, `registry-check.ts`, ~20 component files | No |
+| 2026-04-22 | 18 | Tailwind removal (92 files) + forgot/reset password flow | All components/pages, `ForgotPasswordScreen.tsx`, `ResetPasswordScreen.tsx` | No |
+| 2026-04-22 | 19 | **Generation overhaul** — exercise muscle groups (488 rows), goal moved to profile, prompt v3.1 rewrite (arc, thematic coherence, muscle intelligence), weekly coverage context, balanced goal upgrade, headless test harness | `00026_exercise_muscle_groups.sql`, `prompt.ts`, `index.ts`, `test-generation.ts` | **Yes** — `exercise_muscle_groups` table, prompt v3.1, coverage context in generation |
+| 2026-04-22 | — | Fabricated token fixes, @layer/@apply removal, CTAButton Tailwind conversion | `index.css`, `CTAButton.tsx` | No |
+| 2026-04-23 | 20 | LLM-reproducible design system — `ui-rules.md`, `token-decision-tree.md`, `anti-patterns.md`, enriched component/chamfered skills, @tokens JSDoc on 5 components | Skills files, `CLAUDE.md` | No |
+| 2026-04-23 | 21 | **Generation screen overhaul** — coverage-based `suggest_anchor()` RPC, auto-anchor with reason, removed interactive AnchorGrid, simplified GenerationScreen | `00027_suggest_anchor_rpc.sql`, `useSuggestedAnchor.ts`, `GenerationScreen.tsx` | **Yes** — `suggest_anchor` RPC, anchor auto-selection |
+| 2026-04-23 | 22 | Smart Training System PRD ticket suite — 8 GitHub Issues (#34–#41), closed superseded issues | No code — planning only | No |
+| 2026-04-24 | 23 | **Set-by-set logging** — `exercise_set_logs` table, `get_last_set_data` RPC, per-set inputs in ActiveExerciseCard, pre-fill from last session, 22 unit tests | `00028_exercise_set_logs.sql`, `00029_get_last_set_data_rpc.sql`, `ActiveExerciseCard.tsx`, `workout-api.ts` | **Yes** — `exercise_set_logs` table, per-set tracking |
+| 2026-04-24 | — | Deployed 7 pending migrations to production, linked Supabase CLI | No code — infra | No |
+| 2026-04-24 | — | Fixed sign-out hanging on Vercel, SPA rewrite rule, password reset email URLs | `AuthContext.tsx`, `vercel.json` | No |
+| 2026-04-25 | 24 | Integration gap audit — `withTimeout` utility, silent failure fixes in favorites-api, cross-tab sign-out, mount safety guards, dev route gating | `async-utils.ts`, `workout-api.ts`, `favorites-api.ts`, `AuthContext.tsx` | No |
+| 2026-05-21 | — | Claude Code hooks infrastructure — design-system-lint, branch-guard, UI preflight nudge, shared hook-utils | `.claude/hooks/*.sh`, `.claude/settings.json` | No |
+
+---
+
+## 2. Workout Generation: Current State
+
+### Prompt Version
+**v3.1.0** — live in `supabase/functions/generate-workout/prompt.ts`
+
+### System Prompt
+Full prompt is in `supabase/functions/generate-workout/prompt.ts` (437 lines). Too long to paste — read that file directly. Key sections:
+
+1. **THE ARC** — workout as one continuous intensity curve (ramp → peak → descend)
+2. **THEMATIC COHERENCE** — every exercise serves one central movement idea
+3. **MUSCLE GROUP INTELLIGENCE** — uses muscle tags for warmup/accessory/cooldown selection
+4. **TRAINING GOALS** — strength, hypertrophy, conditioning, balanced, active_recovery with time allocations and section rules
+5. **INTENSITY MODEL** — movement difficulty, rep counts, set counts, rest periods, load percentages all scale by 1-10
+6. **STRUCTURE TYPES** — standard, superset, circuit, emom, amrap, for_time with group_id rules
+7. **REP SCHEMES** — fixed, ladder_down/up, pyramid, inverse, n_plus_one, ladder_fixed_interval
+8. **SECTION SCALING** — warmup (3-phase: general → pattern prep → ramp), primary lift, accessory, core, conditioning, cooldown
+9. **WEEKLY COVERAGE** — uses 7-day muscle group aggregation to balance programming
+10. **HISTORY-AWARE BALANCING** — avoids repeating anchors, exercises, structures
+
+### Inputs to Generation
+
+The handler (`supabase/functions/generate-workout/index.ts`) builds a user prompt from:
+
+| Input | Source | Notes |
+|-------|--------|-------|
+| `intensity` (1-10) | Per-request | Required |
+| `anchor` (string) | Per-request (auto-suggested by `suggest_anchor()` RPC) | Required |
+| `duration_mins` | Per-request | Required |
+| `goal` | Profile `goal_preset` or request override | Defaults to `balanced` |
+| `experience_level` | Profile or request override | Defaults to `some` |
+| `limitations` | Profile or request override | Freeform text |
+| `enabled_sections` | Profile or request override | Array of section types |
+| `equipment` | Location table (via `location_id`) or direct array | Fetched from `locations` table |
+| `notes` | Per-request | Optional freeform |
+| Recent 5 sessions | `workout_sessions` query | Anchors + exercise IDs for variety |
+| Weekly coverage | `buildCoverageContext()` | 7-day muscle group aggregation (primary/synergist counts + recency) |
+| Exercise library | `exercise_definitions_with_anchors` view | Filtered by available equipment + enabled sections. Includes `id`, `name`, `equipment_options`, `sections`, `anchors`, `primary_anchor`, `muscle_groups`, `regression` |
+
+### Deviations from v3 Spec
+
+The v3 spec (`docs/specs/workout-generation-prompt-v3.md`) was a draft. The shipped prompt (v3.1.0) differs:
+
+1. **Coaching cues removed from exercise listing** — cues bloated the prompt. Muscle group data replaced them (net neutral tokens). Decision: session 19.
+2. **Goal moved from per-workout to profile** — v3 spec assumed per-workout goal selection. Shipped version reads from `profiles.goal_preset` set during onboarding. Decision: session 19.
+3. **Anchor auto-selected by RPC** — v3 spec assumed manual anchor selection. Shipped version uses `suggest_anchor()` RPC based on weekly muscle coverage. User can override via notes field. Decision: session 21.
+4. **`balanced` goal upgraded** — v3 treated balanced as "a bit of everything." Shipped version has specific time allocations, weekly coverage adaptation, and explicit structure variety rules. Decision: session 19.
+5. **Warmup rewritten as 3-phase flow** — v3 had generic warmup. Shipped version has: general movement → pattern prep (using muscle tags from primary lift) → ramp to working intensity. Decision: session 19.
+
+### Output Schema
+
+`GeneratedExercise` and `GeneratedSection` types in `index.ts` (lines 48-68):
+
+```typescript
+interface GeneratedExercise {
+  exercise_id: string;
+  name: string;
+  equipment: string;
+  sets: number | null;
+  reps: string;
+  effort_percent: number | null;
+  tempo: string | null;
+  rest_seconds: number | null;
+  coaching_cues: string[];
+  regression: string | null;
+  structure: ExerciseStructure;
+}
+
+interface GeneratedSection {
+  section_type: string;
+  section_title: string;
+  section_notes: string | null;
+  estimated_duration_mins: number;
+  exercises: GeneratedExercise[];
+}
+```
+
+Note: `coaching_cues` is still in the output type but the prompt no longer includes cues in the exercise library listing (Claude generates them from scratch).
+
+---
+
+## 3. Database Schema Changes
+
+### New Tables (since Feb 27)
+
+| Migration | Table | Purpose |
+|-----------|-------|---------|
+| `00024_create_saved_workouts.sql` | `saved_workouts`, `saved_workout_completions` | Favorites system — snapshot workout JSON + completion tracking |
+| `00025_add_exercise_structure.sql` | (column additions) | `structure` JSONB on exercises table for superset/circuit/emom/amrap/for_time |
+| `00026_exercise_muscle_groups.sql` | `exercise_muscle_groups` | Junction table: 488 rows mapping ~140 exercises → 18 muscle groups with primary/synergist/stabilizer roles. Updated `exercise_definitions_with_anchors` view to include muscle data. |
+| `00027_suggest_anchor_rpc.sql` | (RPC) | `suggest_anchor()` — queries 7-day coverage, scores body regions by staleness, returns suggested anchor + reason |
+| `00028_exercise_set_logs.sql` | `exercise_set_logs` | Per-set tracking: `exercise_row_id`, `set_number`, `weight` (NUMERIC), `reps`, `rpe`, `is_warmup_set`. RLS via FK chain. |
+| `00029_get_last_set_data_rpc.sql` | (RPC) | `get_last_set_data()` — returns per-exercise set history from most recent completed session, with legacy `weight_logged` fallback |
+
+### Column Changes
+
+- `exercises` table gained `structure` JSONB column (migration 00025)
+- `workout_sessions` gained `status` enum used by coverage queries
+
+### RLS Policy Changes
+
+- `exercise_set_logs` has RLS policies via FK chain through `exercises` → `workout_sections` → `workout_sessions` (user_id)
+- `suggest_anchor()` and `get_last_set_data()` RPCs use `SECURITY DEFINER` to query across tables
+
+### No Data Model Spec Doc Found
+
+There is no `Clear_-_Data_Model_UPDATED.md` in the repo. Spec docs are in `docs/specs/` but none cover the full schema. The actual schema is defined by the migration files in `supabase/migrations/`.
+
+---
+
+## 4. Frontend Architecture
+
+### Routing Structure (`src/App.tsx`)
+
+```
+Public:
+  /welcome          → WelcomeScreen
+  /sign-in          → SignInScreen
+  /create-account   → CreateAccountScreen
+  /forgot-password  → ForgotPasswordScreen
+
+Unguarded:
+  /reset-password   → ResetPasswordScreen (user arrives authenticated via recovery link)
+
+Onboarding:
+  /onboarding       → OnboardingScreen
+
+Protected:
+  /                 → HomeScreen
+  /generate         → GenerationScreen
+  /review           → ReviewScreen
+  /workout          → WorkoutScreen
+  /summary          → SummaryScreen
+  /history          → HistoryScreen
+  /history/:id      → SessionDetailScreen
+  /settings         → SettingsScreen
+
+Dev-only (import.meta.env.DEV):
+  /dev/gallery      → ComponentGallery
+  /dev/test-workout → TestWorkoutScreen
+```
+
+### New Components (since Feb 27)
+
+| Component | Purpose |
+|-----------|---------|
+| `TabbedPanel` | Compound tabs + content in single chamfered SVG frame |
+| `FilterDropdown` | Chamfered dropdown for history/favorites filtering |
+| `WorkoutListItem` | Reusable workout history row |
+| `FavoriteListItem` | Reusable favorite workout row |
+| `WeekStreakDisplay` | Week-view streak visualization |
+| `ConfirmationModal` | Generic confirm/cancel modal (replaced AbandonmentModal) |
+| `EmptyState` | Reusable empty state with icon + message |
+| `icons.tsx` | Custom icon system replacing Lucide |
+
+### Major Refactors
+
+1. **Tailwind fully removed** (session 18) — all 92 files converted to inline styles with CSS custom properties. `tailwind.config.ts` deleted, `@tailwind` directives removed, `cn()` utility removed, 11 shadcn/ui primitives deleted.
+2. **All primitive tokens eliminated** (session 17) — every component now uses semantic tokens only. `token-lint.ts` script enforces this.
+3. **Goal selection removed from GenerationScreen** (session 19) — goal reads from profile, set during onboarding/settings.
+4. **Anchor auto-selection** (session 21) — `useSuggestedAnchor` hook calls `suggest_anchor()` RPC, replaces interactive AnchorGrid.
+
+### State Management
+
+- `AuthContext` — auth state, profile, locations, sign-in/out
+- `HomeDataContext` — workout history, streak data, incomplete session detection
+- `WorkoutFlowContext` — generation → review → workout → summary flow state
+- React Query for server state (favorites, history)
+
+### Design System Status
+
+- **37 token-lint violations remaining** — all 37 are in `ComponentGallery.tsx` (museum/demo page, intentionally uses primitive tokens for color swatches). Zero violations in production code.
+- All production components use semantic tokens exclusively.
+
+---
+
+## 5. Active Issues & In-Flight Work
+
+### Open PRs
+None. All branches merged.
+
+### Unmerged Branches
+Only `main` exists locally. All feature branches have been cleaned up.
+
+### Uncommitted Files
+- `docs/guide-training-llm-on-design-system.md` — untracked doc file
+
+### Known Generation Quality Issues
+These were identified during a test generation on 2026-05-21 (intensity 7, 60min, balanced, hinge):
+
+1. **Primary lift too weak** — generated Single-Leg RDL as primary on a hinge day with barbell available. Should have been barbell RDL or conventional deadlift.
+2. **Conditioning disconnected from theme** — push-ups and mountain climbers on a hinge day. Should be KB swings, deadlift variations, or rowing.
+3. **Core is generic** — plank + side plank regardless of session theme. Should complement the primary (dead bugs, Pallof press for hinge).
+4. **No timed/clock element in main work** — balanced goal at intensity 7 should have at least one timed structure. Generated all standard sets.
+5. **Warmup generic** — cat-cow appears regardless of session type. Warmup exercises should relate to the actual workout movements.
+
+### In-Flight Feature Work (current session)
+
+Two new ticket groups created 2026-05-21:
+- **#50** — Single-page workout view mode (status: ready)
+- **#51** — Adaptive workout generation — per-user learning (status: needs-detail, broken into #52-#56)
+  - #52: Capture workout-level feedback (ready)
+  - #53: Track exercise swap signals (ready)
+  - #54: Build user model aggregation (blocked on #52+#53)
+  - #55: Inject user model into generation prompt (blocked on #54)
+  - #56: Calibration screen / preference UI (blocked on #54+#55)
+
+**Current priority: Fix base generation quality BEFORE layering adaptive learning.**
+
+---
+
+## 6. Specs That Are Stale
+
+| Spec | Location | Discrepancy |
+|------|----------|-------------|
+| `workout-generation-prompt-v3.md` | `docs/specs/` | Draft spec. Shipped prompt is v3.1.0 with significant changes: no coaching cues in library, goal from profile not per-workout, anchor auto-selected, balanced goal rewritten, warmup as 3-phase flow. **Read `supabase/functions/generate-workout/prompt.ts` instead.** |
+| `Clear_-_Workout_Generation_Prompt_v2.md` | `docs/specs/` | Fully superseded by v3.1.0. |
+| `Clear_-_Favorites_Spec.md` / `v2` | `docs/specs/` | Implementation shipped (session 15). May have diverged on details — code is source of truth. |
+| `Clear_-_Exercise_Swap_Spec.md` | `docs/specs/` | Implementation shipped. `generate-section` edge function exists. Code is source of truth. |
+| `Clear_-_Intensity_Model_Spec.md` | `docs/specs/` | Superseded by intensity model in prompt v3.1.0. |
+| `Clear_-_Structure_Types_Spec.md` | `docs/specs/` | Superseded by structure types in prompt v3.1.0. |
+| `CLAUDE_AI_PLANNING_GUIDE.md` | `docs/` | Written for Claude.ai planning sessions. May reference outdated file paths or workflows. |
+
+---
+
+## 7. Open Questions for the Designer
+
+1. **Generation quality vs. adaptive learning priority** — Eric wants to fix base generation quality first (workouts feel generic, not thematic), then layer per-user learning. The Alchemy Coach Training Manual has been ingested as reference material (`docs/alchemy-manual-digest.md`). Key principles to carry forward: thematic coherence, warmup as movement prep (not generic stretches), compressed timed intensity for main work, conditioning that complements the primary. **NOT** a 1:1 Alchemy clone — Eric explicitly doesn't want longer warmups or yoga flows (no coach to guide them on a phone).
+
+2. **"Balanced" goal identity** — balanced is the default goal but the generation still feels generic. Should balanced have sub-modes or weekly personality? The prompt tries to use weekly coverage to vary emphasis, but the output is still flat.
+
+3. **Goal simplification** — Eric questioned whether the 5 goals (strength/hypertrophy/conditioning/balanced/active_recovery) are over-engineered. From generation philosophy: "goals should influence CHARACTER, not dictate WHICH SECTIONS appear." The current prompt still uses goals to determine section templates.
+
+4. **Monthly focus/challenge** (#29) — open ticket, no spec yet. How should this interact with goal and the adaptive system?
+
+5. **Alchemy-like workout mode** — Eric mentioned wanting the ability to generate Alchemy-style workouts (timed main work, flow warmup, compressed intensity). Probably a separate goal preset or generation "style" — needs design.
+
+---
+
+## 8. Backlog Snapshot
+
+Backlog has been migrated to GitHub Issues. Top items by current priority:
+
+| # | Title | Status | Blocked? |
+|---|-------|--------|----------|
+| — | **Fix base generation quality** | Active (not ticketed — current focus) | No |
+| #50 | Single-page workout view mode | Ready | No |
+| #52 | Adaptive gen Phase 1: Capture workout-level feedback | Ready | No |
+| #53 | Adaptive gen Phase 2: Track exercise swap signals | Ready | No |
+| #35 | Rest timer between sets | Ready | No |
+| #37 | Coaching cues from database | Ready | No |
+| #36 | Progressive overload engine | Ready | No |
+| #38 | Smart intensity defaults | Ready | No |
+| #39 | Workout insights & analytics | Ready | No |
+| #29 | Monthly focus/challenge system | Needs detail | No |
+
+Blocked items: #54 (on #52+#53), #55 (on #54), #56 (on #54+#55).
+
+Not listed above but relevant: #18 (circuit auto-progress), #34 (set-by-set logging — shipped), #21 (dev-only gate — shipped).
+
+---
+
+## Key Files to Read First (5-minute version)
+
+1. **`supabase/functions/generate-workout/prompt.ts`** — The full system prompt (v3.1.0). This IS the generation logic. 437 lines, everything from goal templates to intensity scaling to warmup structure.
+
+2. **`docs/alchemy-manual-digest.md`** — Distilled principles from the Alchemy Coach Training Manual. This is the reference material for generation quality tuning. Key sections: shimming (warmup philosophy), bell curve, class structure, movement hierarchy.
+
+3. **`docs/SESSION_LOG.md` sessions 19 + 21** — The two architectural sessions: generation overhaul (muscle groups, prompt v3.1, coverage context) and generation screen simplification (auto-anchor, goal from profile). These are the biggest changes since Feb 27.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-05-21 (24th session)
+**Last Session:** 2026-05-26 (27th session)
 
 ---
 
@@ -13,14 +13,164 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** Smart Training System — Phase 1 deployed
+**Current Phase:** UI polish + discovery
 **Current Task:** None
-**Last Completed:** Claude Code hooks infrastructure — automated design system checks
-**Blocking Issues:** 37 token-lint violations pending
+**Last Completed:** UI polish batch + Strava comparative analysis tickets
+**Blocking Issues:** None
 
 ---
 
 ## Session Entries
+
+### Session: 2026-05-26 - UI Polish + Strava Comparative Analysis
+
+**Duration:** ~1.5 hrs
+**Mode:** Claude Code
+**Branch:** `fix/generation-screen-polish` (committed, not yet PR'd)
+
+#### What Got Done
+- **UI polish from annotated screenshots:**
+  - Added `font-weight: bold` to all `text-heading-h*` CSS classes (design philosophy says headings are always bold, but classes were missing it)
+  - Increased textarea and input padding from spacing-200/300 to spacing-300/400 for better breathing room
+  - Fixed RadioButton description text alignment when wrapping (`textAlign: 'left'`)
+  - Updated Balanced goal description from vague "Adapts to your week" to factual "Equal parts strength, conditioning & mobility"
+- **Section guide refactor:**
+  - Discovered 3 phantom section types (Skill/Power, Carries, Stability/Balance) defined in UI but never supported by the AI generation prompt
+  - Converted "Customize Sections" toggleable chips to read-only "Section Guide" showing definitions
+  - Removed phantom section types from `SectionType` union, `WORKOUT_SECTIONS`, and mapping files
+  - Sections now always derived from `SECTIONS_BY_GOAL[goal]` — no user override
+- **Strava comparative analysis:**
+  - Reviewed Strava deep-dive PDF + synthesis (from separate Tally project) through CLEAR lens
+  - Identified 5 enhancement opportunities for CLEAR
+  - Created tickets #61-#65 and added all to project board
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Remove section customization UI | Prompt doesn't support custom section combos well; letting users toggle sections they don't understand risks incoherent workouts |
+| Remove phantom section types entirely | skill_power, carries, stability_balance were never in the AI prompt's vocabulary — dead code that created confusion |
+| Sections derived from goal, not user-overridable | Simpler, more reliable, and the prompt is tuned for specific section combos per goal |
+| All 5 Strava insights as standalone tickets (not comments) | Comments on existing issues get buried; standalone tickets are searchable and trackable |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `src/index.css` | Modified — added font-weight: bold to all heading classes |
+| `src/components/ui/textarea.tsx` | Modified — increased inner padding |
+| `src/components/ui/input.tsx` | Modified — increased inner padding |
+| `src/components/RadioButton.tsx` | Modified — added textAlign: left to description span |
+| `src/types/workout.ts` | Modified — removed 3 phantom section types, updated Balanced description |
+| `src/pages/settings/StructureSettings.tsx` | Modified — replaced chip toggles with section guide definitions |
+| `src/pages/SettingsScreen.tsx` | Modified — removed section toggle state/handlers |
+| `src/lib/section-mapping.ts` | Modified — removed phantom entries from DB/API mappings |
+| `src/hooks/useWorkoutGeneration.ts` | Modified — removed phantom entries from section map |
+
+#### Tickets Created
+| # | Title | Labels |
+|---|-------|--------|
+| #61 | Onboarding: add intent/motivation question | enhancement, P3, area:ui |
+| #62 | Progression visualization: milestone grid | enhancement, P3, area:ui |
+| #63 | Surface feel ratings in session history | enhancement, P3, area:ui |
+| #64 | Monthly training challenges | enhancement, P3, area:ui |
+| #65 | Long-arc training analytics | enhancement, P3, area:data |
+| #67 | Design system assembly reference + skill maintenance | enhancement, P2, area:workflow |
+
+#### Skill Audit & Fixes
+- Audited all 23 skills for staleness — found 4 broken
+- Fixed `execute-plan.md` and `inbox-workflow.md`: TodoWrite -> TaskCreate/TaskUpdate
+- Fixed `pr-workflow.md`: absolute path references -> relative
+- Fixed `close-session.md`: memory file path reference
+- Created #67 for assembly reference (LEGO-style composition recipes) and drift prevention strategy
+
+#### Status
+- Build passes, typecheck passes
+- 1 commit on `fix/generation-screen-polish` — not yet PR'd (stashed for future UI work)
+- Skill fixes are on main (uncommitted doc changes)
+
+---
+
+### Session: 2026-05-22 - Fix QueryClientProvider Crash
+
+**Duration:** ~15 min
+**Mode:** Claude Code
+**Branch:** `fix/query-client-provider-order` (merged via PR #60)
+
+#### What Got Done
+- **Diagnosed runtime crash:** "No QueryClient set, use QueryClientProvider to set one" — app was completely broken in production
+- **Root cause:** `AuthProvider` (which calls `useQueryClient()`) was rendered outside `QueryClientProvider` in `main.tsx`, while `QueryClientProvider` lived inside `App.tsx`
+- **Fix:** Moved `QueryClient` creation and `QueryClientProvider` from `App.tsx` up to `main.tsx`, wrapping `AuthProvider`. Removed duplicate from `App.tsx`.
+- **Merged via PR #60** — squash merge, branch deleted
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Move QueryClientProvider to main.tsx | Must wrap AuthProvider since AuthContext uses useQueryClient(). main.tsx is the natural home for top-level providers. |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `src/main.tsx` | Modified — added QueryClient creation + QueryClientProvider wrapping AuthProvider |
+| `src/App.tsx` | Modified — removed QueryClient creation + QueryClientProvider (no longer needed here) |
+
+#### Status
+- Build passes, typecheck passes
+- PR #60 merged to main
+- Blocking issue from session 25 resolved
+
+---
+
+### Session: 2026-05-21 - Workout Anatomy Spec Implementation
+
+**Duration:** ~2 hrs
+**Mode:** Claude Code
+**Branch:** `feature/workout-anatomy-spec` (merged via PR #59)
+
+#### What Got Done
+- **Schema migration (00030):** Added `component_movements TEXT[]` and `exercise_role TEXT` to `exercise_definitions`, retired `surprise` anchor → `full_body`, dropped `quick` goal → `balanced`, added `hypertrophy` + `active_recovery` to goal enum, collapsed `movement_patterns` table entirely, recreated dependent views and functions
+- **Exercise tagging (00031):** Tagged all 140 exercises with component_movements arrays (20-primitive vocabulary) and exercise_role values (7 roles: compound_lift, accessory, activation, mobility, conditioning, stability, cardio)
+- **Frontend cleanup:** Removed `SURPRISE` from `AnchorType`, deleted `resolveSurprise()` from anchor-mapping, deleted dead `AnchorGrid` component, cleaned up ComponentGallery
+- **System prompt v4.0:** Complete rewrite — replaced section-template model with thematic framework (focal/contrasting/prep-recovery/general relationships), goal-as-character with ratio targets per goal, component-driven warmup logic, muscle-targeted cooldown, variety rule (no >75% component overlap in a section)
+- **Edge function updates:** Both `generate-workout` and `generate-section` now include `component_movements` and `exercise_role` in exercise listings, warmup component verification (logging only), swap prompt updated with component overlap matching
+- **Test harness updates:** Added component coverage validation and variety rule validation to `scripts/test-generation.ts`
+- **Regenerated database types** after schema migration
+
+#### What Came Up (Unexpected)
+- `supabase db execute` command doesn't exist in our CLI version — used `supabase db query` instead
+- Enum scan error (`unknown oid`) when querying anchor_type after swap — fixed by casting to text
+- `active_recovery` goal test produced `"type": "timed"` for foam rolling — pre-existing edge case, not a v4.0 regression
+- **Runtime error post-merge:** "No QueryClient set, use QueryClientProvider" appeared in screenshot — needs investigation next session
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Collapse movement_patterns entirely | exercise_anchors junction already had all anchor data; movement_patterns was dead weight |
+| 48 surprise exercises become anchor-less | These (core, conditioning, mobility, carries) are genuinely not pattern-anchored — selected by exercise_role instead |
+| Warmup verification is logging-only in v1 | Non-fatal — lets us observe coverage gaps before making it a hard gate |
+| Variety rule validation warns, doesn't reject | Same approach — collect data before enforcing |
+| Keep `active_recovery` timed structure edge case | Pre-existing issue, not introduced by v4.0 |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `supabase/migrations/00030_workout_anatomy_schema.sql` | Created — Schema migration: new fields, enum swaps, table collapse |
+| `supabase/migrations/00031_tag_exercises.sql` | Created — Tag all 140 exercises with components + roles |
+| `src/types/database.ts` | Regenerated — Includes new fields and updated enums |
+| `src/types/workout.ts` | Modified — Removed SURPRISE from AnchorType |
+| `src/lib/anchor-mapping.ts` | Modified — Removed resolveSurprise, default → resolveFullBody |
+| `src/components/AnchorGrid.tsx` | Deleted — Dead component |
+| `src/pages/ComponentGallery.tsx` | Modified — Removed AnchorGrid section |
+| `supabase/functions/generate-workout/prompt.ts` | Rewritten — System prompt v4.0 |
+| `supabase/functions/generate-workout/index.ts` | Modified — New fields, warmup verification, v4.0.0 |
+| `supabase/functions/generate-section/index.ts` | Modified — New fields, swap prompt updates |
+| `scripts/test-generation.ts` | Modified — Component + variety validations |
+
+#### Status
+- Build: passing
+- TypeScript: clean
+- 1 squash commit merged to main via PR #59
+- Runtime error ("No QueryClient set") observed — may need investigation
+
+---
 
 ### Session: 2026-05-21 - Claude Code Hooks Infrastructure
 

--- a/docs/alchemy-manual-digest.md
+++ b/docs/alchemy-manual-digest.md
@@ -1,0 +1,199 @@
+# Alchemy Coach Training Manual — Digest for CLEAR Generation
+
+> Extracted from the Alchemy 365 Coach Training Prep Manual (23 pages).
+> This is a reference for workout generation prompt tuning. NOT Alchemy branding — principles only.
+
+---
+
+## Class Structure (p.9-10)
+
+The Alchemy 365 class is a 50-minute session with this exact structure:
+
+| Phase | Duration | What Happens |
+|-------|----------|-------------|
+| Pre-class | 5-10 min | Setup, equipment, space |
+| Chalkboard | 3-7 min | Overview of workout, demo movements, modifications |
+| Segue | ~1 min | Three breaths, transition to movement |
+| **Warm-up + Shims** | **12-16 min** | 1-2 Sun A + 1-2 Sun B sequences, with "shims" interspersed |
+| Regroup | 1 min | Water, adjust weight, build hype, countdown: 3...2...1...GO! |
+| **Workout** | **~20 min** | Timed main work |
+| Clearing | 2-4 min | Enjoy the moment, wipe gear, return to spaces |
+| **Cool-down** | **4-7 min** | Sun A/Sun B/Floor hybrid targeting muscles worked that day |
+| Segue | ~1 min | Three breaths seated, round of applause |
+| Announcements | 30 sec | Brief |
+
+**Key insight for CLEAR:** The workout itself is only ~20 minutes of a 50-minute class. The warmup (12-16 min) and cooldown (4-7 min) are substantial and intentional — they're not afterthoughts. The warmup is nearly as long as the workout.
+
+---
+
+## The Bell Curve (p.11)
+
+The bell curve describes *how* a class is delivered, not just *what* happens. It's a graph of **intensity variables** (volume, voice, pace, vibe) over time:
+
+- Starts low (~2) at minute 0
+- Gradually ramps through warmup
+- Peaks around minute 20-30 (during the workout)
+- Comes back down through clearing and cooldown
+- Ends low at minute 50
+
+**The curve is smooth and continuous.** There's no abrupt jump from warmup to workout. The warmup progressively builds intensity so that by the time the workout starts, athletes are already at ~6-7 and ready to push to 8-9.
+
+**Key insight for CLEAR:** The bell curve isn't just exercise difficulty — it's the entire *feel* of the session. The warmup builds energy, the workout channels it, the cooldown releases it. This is the arc we talked about.
+
+---
+
+## Shimming — The Secret Sauce of the Warmup (p.7-8)
+
+A "shim" is anything in the warm-up that's outside the basic yoga sequencing which helps prepare for the workout. Three categories:
+
+### 1. Joint and Muscle Prep
+Done early when bodies are still cold. Targets the specific joints/muscles needed for today's workout.
+- Heavy squat day → hip grinding, flossing in/out of half splits, monkey squats, crescent moon
+- These get the relevant joints warm and mobile
+
+### 2. General Heat Building
+Gets athletes breathing and sweating before the workout begins. Simple, common exercises:
+- Jumping jacks, high knees, mountain climbers, shoulder taps, ground-to-jump-and-touch
+- Simplicity wins — don't invent something new
+
+### 3. Movement Progression (THE CRITICAL ONE)
+Allows athletes to incrementally "build" the movements of the day into their warm-up. Deconstructing the movement to its simplest parts and building back up one part at a time.
+
+**"Each movement needs to be shimmed so that full repetitions of each movement from the workout is completed before the workout begins."**
+
+**"By the time a warm-up is complete, athletes should be sweaty, breathing hard, stretched out, and have had ample opportunities to practice the movements in the workout at a slow, medium, and fast pace."**
+
+**Key insight for CLEAR:** This is the biggest gap in our current generation. The warmup isn't just "get loose" — it's a progressive deconstruction of the workout movements. If the workout has KB swings and deadlifts, the warmup should include hip hinges, straight-leg deadlifts (bodyweight), glute bridges, and eventually full swings at light pace. By end of warmup, you've done every movement in the workout at least once.
+
+**Shimming should be ~50% of the total warmup time.**
+
+---
+
+## Warmup Structure: Yoga + Shims Interleaved (p.4-5, 7-8)
+
+The warmup is NOT pure yoga, and NOT pure exercise. It's a hybrid:
+
+**Sun A sequence:** Standing at attention → Mountain pose → Side body stretch → Forward fold → High plank → Low plank → Upward facing dog → Downward facing dog
+
+**Sun B sequence:** Three-legged down-dog → Low lunge → Crescent lunge → Warrior two → Extended side angle → Reverse warrior → Low lunge → Downward facing dog (both sides)
+
+Shims are placed *sporadically and strategically throughout* — between Sun sequences, during holds, in transitions. The yoga provides the structure and flow; the shims provide the workout-specific prep.
+
+**Key insight for CLEAR:** The yoga flow is a skeleton — coaches have freedom to add postures and shims. For CLEAR (no coach, no yoga background), the warmup should capture the *intent* of yoga + shims without requiring yoga knowledge: progressive, flowing, movement-prep-focused. Not "do Sun A then do squats" — more like a continuous warmup flow that weaves in workout-specific movement prep.
+
+---
+
+## Workout Coaching Phases (p.10)
+
+The 20-minute workout has three internal phases:
+
+1. **First 25%** — Focus on seeing and correcting mechanics. Help athletes know where to be and when.
+2. **Middle 50%** — 1:1 coaching, personal touch points, time checks.
+3. **Final 25%** — Foster intensity, push the class to finish strong.
+
+**Key insight for CLEAR:** The workout arc WITHIN the timed portion mirrors the overall bell curve. First quarter is settling in, middle is cruising, final quarter is peak intensity/push. Timer-driven sections in CLEAR should acknowledge this — e.g., coaching cues could shift from form-focused early to push-focused late.
+
+---
+
+## Cool-down Details (p.10)
+
+- Sun A/Sun B/Floor Sequence hybrid
+- Targets muscles/body parts worked during the workout that day
+- Basic, low-impact stretches
+- Don't overcomplicate it
+- Final Resting Pose (FRP) lasts ~90 seconds
+- After FRP, slowly brought to seated, three breaths to cap off
+
+**Key insight for CLEAR:** Cooldown is straightforward — stretch what you used, keep it simple. Our generated cooldowns are already close to this. The 90-second FRP is interesting — a deliberate stillness moment to end.
+
+---
+
+## Foundational Movements (p.14-23)
+
+The manual catalogs these as the Alchemy movement library with setup, focal points, and common faults:
+
+| Movement | Category | Notes |
+|----------|----------|-------|
+| Air Squat | Squat | Foundation. Feet shoulder width, weight in heels, lumbar activity |
+| Front Squat | Squat | Air squat + front rack position, elbows up |
+| Straight Leg Deadlift | Hinge | Feet under hips, hinge from hip, lower to hamstring tension |
+| Deadlift | Hinge | Hip width, hip above knee, shoulder above hip. Translation → Rotation |
+| Ground to Shoulder | Power/Hinge | Deadlift setup → accelerate through middle with hips → pull to shoulder |
+| Ground to Overhead | Power | Deadlift setup → accelerate → follow through to OH |
+| Slam Ball Squat Clean | Power | Similar to deadlift but hips slightly lower. Full hip extension, timing of pull |
+| Press | Press | Hip width, weight on rack, load path focus |
+| Push Press | Press | Same as press + vertical dip and drive, full hip extension, C2E motor recruitment |
+| Split Jerk | Press/Power | Front rack → dip → drive → punch under → split lunge position |
+| Single Arm Snatch | Power | Similar to clean, implement dependent. Full hip extension, timing of pull |
+| Swing | Hinge | Weight hanging loose, arms relaxed, hinge at hips with soft knee, drive hips open |
+| Bent Over Row | Pull | Hinge forward with soft knee, weight in heels, pull to chest pinching shoulder blades |
+| Jumping Pull-up | Pull | Bar at mid forearm, hips underneath, jump and pull |
+| Pull-up | Pull | Hang, engaged core/shoulders, chin above and in front of bar |
+| Toes to Bar | Core/Pull | Hanging, close shoulder and bring toes to bar, lower under control |
+| Ring Row | Pull | Laying back, arms extended, pinch shoulder blades, pull chest to bar |
+| Ring Dip | Press | Top of rings, pinch into sides, hinge forward, shoulder below elbow, press |
+| Lunge | Squat/Single-leg | Step out 3 feet, back knee to floor, front knee over heel, press through front heel |
+
+**Key recurring principle: C2E (Core to Extremity)** — power flows from core outward. Multiple movements list "C2E infraction (early pull/press)" as a common fault. This means athletes pulling with arms before the hips have driven — the movement should originate from the hips/core and transfer outward.
+
+**Key insight for CLEAR:** These movements form a natural hierarchy. Every complex movement deconstructs into simpler parts: ground-to-overhead deconstructs into deadlift → ground-to-shoulder → press. This is exactly how shims should work — build from simple to complex. The exercise library should reflect these relationships.
+
+---
+
+## Posture → Action → Cue Framework (p.5-7)
+
+How Alchemy coaches communicate movement:
+1. **Posture** — name the position you're moving toward
+2. **Action** — describe the physical action to get there
+3. **Cue** — polish/refine the position
+
+Example: "Mountain Pose" (posture) → "Reach hands above your head" (action) → "Bring ribs down, roll shoulders down back" (cue)
+
+**Key insight for CLEAR:** Our coaching cues on exercises should follow this pattern. Not just "squeeze shoulder blades" — but the action first, then the refinement. This could improve our coaching cue format.
+
+---
+
+## What This Confirms From Our Philosophy
+
+1. **The Arc / Bell Curve** — Confirmed with actual graph. Smooth ramp 0→peak→0 over full session.
+2. **Warmup = Movement Prep** — Confirmed and *stronger than we thought*. Shimming = 50% of warmup. Every workout movement practiced before workout starts.
+3. **Thematic Coherence** — Implicit in shimming philosophy. The warmup is *derived from* the workout, not independent of it.
+4. **Cooldown targets muscles used** — Explicitly stated: "targeting the muscles/body parts that were worked during the workout that day."
+5. **C2E (Core to Extremity)** — Confirmed as foundational principle across all power movements.
+
+## What This Corrects or Adds
+
+1. **Warmup is WAY more substantial than we generate.** 12-16 min in a 50-min class = ~28% of total time. Our generated warmups are 5-8 min in a 60-min session = ~10%. Should be closer to 12-15 min.
+2. **Three shim categories, not one.** We were treating warmup as "movement prep" only. It's actually: joint/muscle prep (mobility) → heat building (cardio) → movement progression (skill). All three interwoven.
+3. **Movement deconstruction is explicit.** Not just "do related movements" — literally break the workout movements into component parts and practice each part, building up to full reps at slow → medium → fast pace.
+4. **The workout portion is timed and intense but SHORT.** ~20 min of a 50-min class. The intensity is compressed, not spread thin. This supports Eric's love of timed blocks.
+5. **Workout has internal phases** (first 25% = mechanics, middle 50% = cruise, final 25% = push). The pacing within the workout isn't flat.
+6. **Heat building in warmup is a distinct goal.** Athletes should be "sweaty, breathing hard" before the workout starts. The warmup isn't just stretching — it has a cardio component.
+
+---
+
+## Implications for Generation Prompt
+
+### Warmup Overhaul
+- Increase warmup duration to 12-15 min for a 60-min session
+- Structure: joint prep → heat building → movement progressions (interleaved, not sequential blocks)
+- EVERY exercise in the workout must have at least one shim/progression in the warmup
+- Athletes should be warm and sweating by end of warmup
+- Movement progressions go: bodyweight component → slow full movement → faster/loaded
+
+### Workout Section
+- Should be the PEAK of the bell curve, not the entire workout
+- Timed structures (AMRAP, EMOM, For Time) are the default for main work — not standard sets
+- Keep it 15-25 min for the main work block
+- Internal pacing: settle in → cruise → push to finish
+
+### Cooldown
+- 4-7 min
+- Specifically target muscles used that day (already doing this)
+- Keep it simple — basic stretches, not complex flows
+- Consider a "final rest" moment (60-90s stillness)
+
+### Exercise Relationships
+- Build a movement hierarchy: complex movements decompose into simpler ones
+- Warmup exercises should be drawn from these decompositions
+- C2E principle should inform exercise selection and cueing


### PR DESCRIPTION
## Summary
- Create `assembly-reference.md` — single starting point for UI work (token cheat sheet, spacing recipes, 6 composition patterns, atmosphere rules)
- Fix 4 stale skills (TodoWrite → TaskCreate/TaskUpdate, broken paths)
- Add file-rename check to PR workflow checklist to prevent future drift
- Log session 27 + add prior session docs

## Changes
- **New:** `.claude/skills/assembly-reference.md`
- **Fixed:** `execute-plan.md`, `inbox-workflow.md`, `pr-workflow.md`, `close-session.md`
- **Updated:** `.claude/README.md` (skill registry)
- **Docs:** `SESSION_LOG.md`, `CATCHUP.md`, `alchemy-manual-digest.md`

## Test plan
- [ ] Docs only — no code changes, no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)