### PR TITLE
Workout screen improvements & anchor-aware generation filtering

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,7 +1,7 @@
 # Session Log
 **Project:** [Name]  
 **Started:** [Date]  
-**Last Session:** 2026-05-26 (27th session)
+**Last Session:** 2026-05-28 (28th session)
 
 ---
 
@@ -13,14 +13,80 @@ Living document to capture progress, decisions, and learnings across sessions. T
 ---
 
 ## Quick Status
-**Current Phase:** UI polish + discovery
-**Current Task:** None
-**Last Completed:** UI polish batch + Strava comparative analysis tickets
+**Current Phase:** Workout screen + generation perf
+**Current Task:** PR ready for review
+**Last Completed:** Workout screen improvements + anchor-aware generation filtering
 **Blocking Issues:** None
 
 ---
 
 ## Session Entries
+
+### Session: 2026-05-28 - Workout Screen & Generation Performance
+
+**Duration:** ~2 hrs
+**Mode:** Claude Code
+**Branch:** `feature/workout-screen-and-generation-perf`
+
+#### What Got Done
+- **Anchor-aware exercise filtering** for workout generation:
+  - Pre-filters exercise library by day's anchor before building LLM prompt
+  - Keeps direct anchor matches, contrasting anchors (for balanced programming), and role-exempt exercises (activation, mobility, conditioning, stability, cardio)
+  - Safety net: falls back to full list if filtered count drops below 20
+  - Logs before/after counts for monitoring
+- **Rest timer** (new component + hook):
+  - `RestTimerBar` — fixed-bottom bar with ChamferedFrame, progress bar, countdown, dismiss
+  - `useRestTimer` — hook with Web Audio API completion sound, auto-dismiss after 2s
+  - Wired through all renderers (SectionRenderer → SupersetRenderer/CircuitRenderer → StructureCards)
+  - Static text "Rest: 90s" replaced with interactive RestButton in supersets/circuits
+- **Per-set completion toggle:**
+  - Added checkbox per set row in ActiveExerciseCard (per-set mode)
+  - `SetLog.completed` field added to type
+  - Completed sets dim to 50% opacity
+- **ActiveExerciseCard grid tightened** for mobile (28→24px touch targets, fixed column widths)
+- **WorkoutLayout simplified** — removed flex column, added footer-aware bottom padding
+- **useWorkoutSession race fix** — deferred navigation waits for workoutNotes state to commit via useEffect
+- **Migration bug fixes** (00027, 00030): suggest_anchor RPC used wrong column (`status` → `completed_at`) and wrong join (`ex.id` → `ex.exercise_id`)
+- **Timer color fix:** `--text-timer` changed from green-400 to green-900 (dark on green, matching selected chip style)
+- **Gallery examples** added for ActiveExerciseCard (weighted + bodyweight) and RestTimerBar (normal + low time)
+- **Created ticket #69** — expand power exercise library (P3, future work)
+- **Memory updated** — added mobile-first responsive rule
+
+#### Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Filter by anchor, not send everything | Smaller prompt → faster generation → better exercise selection (less noise) |
+| Contrasting anchors included (squat↔pull, hinge↔press, etc.) | Prompt's thematic framework requires ~5-15% contrasting exercises for balanced programming |
+| Safety net threshold of 20 exercises | Prevents model starvation on unusual anchor + limited equipment combos |
+| Power gets no contrasting filter | Full-body by nature; self-contained. Noted for future expansion (ticket #69) |
+| Dark text on green timer (green-900) | Matches selected chip pattern — high contrast, consistent with design system |
+
+#### Files Changed
+| File | Action |
+|------|--------|
+| `supabase/functions/generate-workout/index.ts` | Modified — anchor-aware filtering + contrasting anchor map |
+| `src/components/workout/RestTimerBar.tsx` | Created — rest countdown bar with ChamferedFrame |
+| `src/hooks/useRestTimer.ts` | Created — timer hook with audio feedback |
+| `src/components/workout/ActiveExerciseCard.tsx` | Modified — per-set completion, tighter grid, rest button |
+| `src/components/workout/StructureCards.tsx` | Modified — rest buttons in superset/circuit cards |
+| `src/components/workout/SectionRenderer.tsx` | Modified — onRestStart prop threading |
+| `src/components/workout/CircuitRenderer.tsx` | Modified — onRestStart/onSetLog prop threading |
+| `src/components/workout/SupersetRenderer.tsx` | Modified — onRestStart prop threading |
+| `src/hooks/useWorkoutSession.ts` | Modified — deferred navigation race fix |
+| `src/layouts/WorkoutLayout.tsx` | Modified — simplified layout, footer padding |
+| `src/pages/WorkoutScreen.tsx` | Modified — rest timer integration |
+| `src/types/workout.ts` | Modified — SetLog.completed field |
+| `src/index.css` | Modified — --text-timer token updated |
+| `src/pages/ComponentGallery.tsx` | Modified — workout component gallery examples |
+| `supabase/migrations/00027_suggest_anchor_rpc.sql` | Modified — bug fix |
+| `supabase/migrations/00030_workout_anatomy_schema.sql` | Modified — bug fix |
+
+#### Status
+- Build passes, types pass, working tree clean
+- 4 commits, 16 files changed, +638/-93 lines
+- Ready for PR
+
+---
 
 ### Session: 2026-05-26 - UI Polish + Strava Comparative Analysis
 

--- a/src/components/workout/ActiveExerciseCard.tsx
+++ b/src/components/workout/ActiveExerciseCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { ChevronDown, ChevronUp, X, Plus, Clock } from "@/components/icons";
+import { ChevronDown, ChevronUp, X, Plus, Clock, Check } from "@/components/icons";
 import { Exercise, ExerciseSetData, SetLog } from "@/types/workout";
 import { ChamferedFrame } from "../ChamferedFrame";
 import { Card } from "../Card";
@@ -257,6 +257,14 @@ export const ActiveExerciseCard = ({
         emitSetLog(updated);
     };
 
+    const handleToggleSetComplete = (index: number) => {
+        const updated = setLogs.map((s, i) =>
+            i === index ? { ...s, completed: !s.completed } : s
+        );
+        setSetLogs(updated);
+        emitSetLog(updated);
+    };
+
     // Legacy single-input handlers (non per-set exercises)
     const handleWeightChange = (v: string) => {
         setWeight(v);
@@ -464,10 +472,12 @@ export const ActiveExerciseCard = ({
                             {/* Column headers */}
                             <div style={{
                                 display: 'grid',
-                                gridTemplateColumns: hasWeight ? '32px minmax(0, 1fr) minmax(0, 1fr) 28px' : '32px minmax(0, 1fr) 28px',
+                                gridTemplateColumns: hasWeight ? '24px 28px 1fr 56px 24px' : '24px 28px 1fr 24px',
                                 gap: 'var(--spacing-200)',
                                 alignItems: 'center',
                             }}>
+                                {/* Spacer for checkbox column */}
+                                <span />
                                 <span
                                     className="text-label-xs"
                                     style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)' }}
@@ -488,6 +498,7 @@ export const ActiveExerciseCard = ({
                                 >
                                     Reps
                                 </span>
+                                {/* Spacer for remove button column */}
                                 <span />
                             </div>
 
@@ -497,11 +508,25 @@ export const ActiveExerciseCard = ({
                                     key={set.setNumber}
                                     style={{
                                         display: 'grid',
-                                        gridTemplateColumns: hasWeight ? '32px minmax(0, 1fr) minmax(0, 1fr) 28px' : '32px minmax(0, 1fr) 28px',
+                                        gridTemplateColumns: hasWeight ? '24px 28px 1fr 56px 24px' : '24px 28px 1fr 24px',
                                         gap: 'var(--spacing-200)',
                                         alignItems: 'center',
+                                        opacity: set.completed ? 0.5 : 1,
                                     }}
                                 >
+                                    <button
+                                        onClick={() => handleToggleSetComplete(index)}
+                                        style={{
+                                            width: 24,
+                                            height: 24,
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'center',
+                                            color: set.completed ? 'var(--icon-selected)' : 'var(--text-disabled)',
+                                        }}
+                                    >
+                                        <Check size={16} />
+                                    </button>
                                     <span
                                         className="text-label-xs"
                                         style={{ fontWeight: 'bold', textTransform: 'uppercase', color: 'var(--text-disabled)' }}
@@ -527,8 +552,8 @@ export const ActiveExerciseCard = ({
                                     <button
                                         onClick={() => handleRemoveSet(index)}
                                         style={{
-                                            width: 28,
-                                            height: 28,
+                                            width: 24,
+                                            height: 24,
                                             display: 'flex',
                                             alignItems: 'center',
                                             justifyContent: 'center',
@@ -537,7 +562,7 @@ export const ActiveExerciseCard = ({
                                         }}
                                         disabled={setLogs.length <= 1}
                                     >
-                                        <X size={14} />
+                                        <X size={12} />
                                     </button>
                                 </div>
                             ))}

--- a/src/components/workout/ActiveExerciseCard.tsx
+++ b/src/components/workout/ActiveExerciseCard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
-import { ChevronDown, ChevronUp, X, Plus } from "@/components/icons";
+import { ChevronDown, ChevronUp, X, Plus, Clock } from "@/components/icons";
 import { Exercise, ExerciseSetData, SetLog } from "@/types/workout";
+import { ChamferedFrame } from "../ChamferedFrame";
 import { Card } from "../Card";
 import { Input } from "../ui/input";
 import { ExerciseNotes } from "./ExerciseNotes";
@@ -10,6 +11,8 @@ interface ActiveExerciseCardProps {
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
     /** Called with per-set data for exercises that use set-by-set logging */
     onSetLog?: (id: string, data: ExerciseSetData) => void;
+    /** Called when user taps Rest button — triggers rest timer */
+    onRestStart?: (restSeconds: number) => void;
     /** Section type — hides weight/reps for warmup, cooldown, mobility */
     sectionType?: string;
     /** Render without Card wrapper (for use inside structure cards like Superset/Circuit) */
@@ -28,13 +31,20 @@ interface ActiveExerciseCardProps {
 }
 
 const HIDE_INPUTS_SECTIONS = ['warmup', 'cooldown', 'mobility'];
-const WEIGHTED_EQUIPMENT = ['barbell', 'dumbbell', 'dumbbells', 'kettlebell', 'cable', 'machine', 'ez bar', 'trap bar', 'smith machine', 'plate'];
+const WEIGHTED_EQUIPMENT = ['barbell', 'dumbbell', 'dumbbells', 'kettlebell', 'kettlebells', 'cable', 'cable machine', 'machine', 'ez bar', 'trap bar', 'smith machine', 'plate'];
 
 /** Check if a rest value is meaningful (non-zero, non-empty) */
 const hasRest = (rest?: string): boolean => {
     if (!rest) return false;
     const cleaned = rest.toLowerCase().replace(/\s/g, '');
     return cleaned !== '0s' && cleaned !== '0' && cleaned !== '';
+};
+
+/** Parse rest string to seconds */
+const parseRestSeconds = (rest?: string): number => {
+    if (!rest) return 0;
+    const num = parseInt(rest);
+    return isNaN(num) ? 0 : num;
 };
 
 /** Format sets×reps into compact prescription */
@@ -77,17 +87,45 @@ function summarizeSets(sets: SetLog[], hasWeight: boolean): string {
         })
         .filter(Boolean);
 
-    // If all entries are the same, compress to "135×8 ×4 sets" style
     if (parts.length > 1 && parts.every(p => p === parts[0])) {
         return `${parts[0]} (${parts.length} sets)`;
     }
     return parts.join(', ');
 }
 
+/** Reusable rest timer button with chamfered frame */
+export const RestButton = ({ restLabel, onStart }: { restLabel: string; onStart: () => void }) => (
+    <button onClick={onStart} style={{ width: '100%' }}>
+        <ChamferedFrame
+            cornerSize="sm"
+            surfaceColor="var(--surface-timer)"
+            borderColor="var(--border-timer)"
+        >
+            <div
+                className="text-cta-xs"
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 'var(--spacing-200)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    color: 'var(--text-timer)',
+                    padding: 'var(--spacing-200) var(--spacing-300)',
+                }}
+            >
+                <Clock size={14} />
+                Rest {restLabel}
+            </div>
+        </ChamferedFrame>
+    </button>
+);
+
 export const ActiveExerciseCard = ({
     exercise,
     onLog,
     onSetLog,
+    onRestStart,
     sectionType,
     bare = false,
     emomState,
@@ -105,30 +143,43 @@ export const ActiveExerciseCard = ({
     const hasStandardSets = exercise.sets != null && exercise.sets > 0;
     const isTimedStructure = ['emom', 'amrap', 'for_time'].includes(exercise.structure?.type || '');
     const isCircuit = exercise.structure?.type === 'circuit';
-    const showPerSetInputs = showInputs && isNumericReps && hasStandardSets && !isTimedStructure && !isCircuit && !!onSetLog;
+    const canLogSets = showInputs && isNumericReps && hasStandardSets && !isTimedStructure && !isCircuit && !!onSetLog;
 
     const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+    const [showPerSet, setShowPerSet] = useState(false);
     const [note, setNote] = useState(exercise.lastNotes || "");
 
-    // Per-set state (only used when showPerSetInputs)
+    // Rest timer
+    const restSeconds = parseRestSeconds(exercise.rest);
+    const showRestButton = hasRest(exercise.rest) && !!onRestStart;
+
+    // Per-set state
     const [setLogs, setSetLogs] = useState<SetLog[]>(() =>
-        showPerSetInputs ? buildInitialSets(exercise, hasWeight) : []
+        canLogSets ? buildInitialSets(exercise, hasWeight) : []
     );
 
-    // Single-input state (legacy, used when !showPerSetInputs)
+    // Unified single-line state: applies to all sets when not in per-set mode
+    const firstSet = setLogs[0];
+    const [uniformWeight, setUniformWeight] = useState(
+        firstSet?.weight != null ? String(firstSet.weight) : (exercise.weight_logged || exercise.lastWeight || "")
+    );
+    const [uniformReps, setUniformReps] = useState(
+        firstSet?.reps != null ? String(firstSet.reps) : (exercise.reps || "")
+    );
+
+    // Single-input state (legacy — for non per-set exercises like bodyweight)
     const [weight, setWeight] = useState(exercise.weight_logged || exercise.lastWeight || "");
     const [reps, setReps] = useState(exercise.reps || "");
 
     // Emit per-set data on mount if we have pre-fill data
     useEffect(() => {
-        if (showPerSetInputs && setLogs.length > 0) {
+        if (canLogSets && setLogs.length > 0) {
             const summary = summarizeSets(setLogs, hasWeight);
             onSetLog(exercise.id, { sets: setLogs, notes: note || undefined });
             if (summary) {
                 onLog(exercise.id, { weight: summary });
             }
         } else {
-            // Legacy pre-fill
             const prefilled: { weight?: string; notes?: string } = {};
             if (exercise.lastWeight) prefilled.weight = exercise.lastWeight;
             if (exercise.lastNotes) prefilled.notes = exercise.lastNotes;
@@ -142,13 +193,30 @@ export const ActiveExerciseCard = ({
     const emitSetLog = useCallback((updatedSets: SetLog[], updatedNote?: string) => {
         if (!onSetLog) return;
         onSetLog(exercise.id, { sets: updatedSets, notes: updatedNote || note || undefined });
-        // Also write summary to legacy loggedData for backward compat
         const summary = summarizeSets(updatedSets, hasWeight);
         if (summary) {
             onLog(exercise.id, { weight: summary });
         }
     }, [exercise.id, hasWeight, note, onLog, onSetLog]);
 
+    // Uniform weight/reps: update ALL sets at once
+    const handleUniformWeightChange = (v: string) => {
+        setUniformWeight(v);
+        const numVal = v === '' ? undefined : parseFloat(v);
+        const updated = setLogs.map(s => ({ ...s, weight: isNaN(numVal as number) ? undefined : numVal }));
+        setSetLogs(updated);
+        emitSetLog(updated);
+    };
+
+    const handleUniformRepsChange = (v: string) => {
+        setUniformReps(v);
+        const numVal = v === '' ? undefined : parseInt(v);
+        const updated = setLogs.map(s => ({ ...s, reps: isNaN(numVal as number) ? undefined : numVal }));
+        setSetLogs(updated);
+        emitSetLog(updated);
+    };
+
+    // Per-set individual handlers
     const handleSetWeightChange = (index: number, value: string) => {
         const numVal = value === '' ? undefined : parseFloat(value);
         const updated = setLogs.map((s, i) =>
@@ -189,7 +257,7 @@ export const ActiveExerciseCard = ({
         emitSetLog(updated);
     };
 
-    // Legacy single-input handlers
+    // Legacy single-input handlers (non per-set exercises)
     const handleWeightChange = (v: string) => {
         setWeight(v);
         onLog(exercise.id, { weight: v });
@@ -202,7 +270,7 @@ export const ActiveExerciseCard = ({
 
     const handleNoteSave = (v: string) => {
         setNote(v);
-        if (showPerSetInputs) {
+        if (canLogSets) {
             emitSetLog(setLogs, v);
         }
         onLog(exercise.id, { notes: v });
@@ -294,15 +362,11 @@ export const ActiveExerciseCard = ({
                     flexDirection: 'column',
                     gap: 'var(--spacing-300)',
                 }}>
-                    {/* Tempo & Rest details */}
-                    {(exercise.tempo || hasRest(exercise.rest)) && (
-                        <div
-                            className="text-paragraph-sm"
-                            style={{ display: 'flex', flexWrap: 'wrap', columnGap: 'var(--spacing-300)', rowGap: 'var(--spacing-100)', color: 'var(--text-paragraph)' }}
-                        >
-                            {exercise.tempo && <span>Tempo: {exercise.tempo}</span>}
-                            {hasRest(exercise.rest) && <span>Rest: {exercise.rest}</span>}
-                        </div>
+                    {/* Tempo */}
+                    {exercise.tempo && (
+                        <p className="text-paragraph-sm" style={{ color: 'var(--text-paragraph)' }}>
+                            Tempo: {exercise.tempo}
+                        </p>
                     )}
 
                     {/* Coaching Cues */}
@@ -321,7 +385,7 @@ export const ActiveExerciseCard = ({
                     {(exercise.regression || exercise.progression) && (
                         <div
                             className="text-paragraph-sm"
-                            style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-100)', paddingTop: 'var(--spacing-200)', color: 'var(--text-paragraph)' }}
+                            style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-100)', color: 'var(--text-paragraph)' }}
                         >
                             {exercise.regression && (
                                 <p><span style={{ color: 'var(--text-disabled)' }}>Easier:</span> {exercise.regression}</p>
@@ -332,19 +396,81 @@ export const ActiveExerciseCard = ({
                         </div>
                     )}
 
-                    {/* Per-Set Inputs */}
-                    {showPerSetInputs && (
+                    {/* ---- Logging inputs ---- */}
+                    {canLogSets && !showPerSet && (
+                        <>
+                            {/* Single-line uniform inputs */}
+                            <div style={{ display: 'grid', gridTemplateColumns: hasWeight ? 'minmax(0, 1fr) minmax(0, 1fr)' : 'minmax(0, 1fr)', gap: 'var(--spacing-300)' }}>
+                                {hasWeight && (
+                                    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>
+                                        <label
+                                            className="text-label-xs"
+                                            style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)' }}
+                                        >
+                                            Weight
+                                        </label>
+                                        <Input
+                                            type="number"
+                                            inputMode="decimal"
+                                            value={uniformWeight}
+                                            onChange={(e) => handleUniformWeightChange(e.target.value)}
+                                            placeholder="lbs"
+                                        />
+                                    </div>
+                                )}
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>
+                                    <label
+                                        className="text-label-xs"
+                                        style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)' }}
+                                    >
+                                        Reps
+                                    </label>
+                                    <Input
+                                        type="number"
+                                        inputMode="numeric"
+                                        value={uniformReps}
+                                        onChange={(e) => handleUniformRepsChange(e.target.value)}
+                                        placeholder={exercise.reps}
+                                    />
+                                </div>
+                            </div>
+                            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                <span
+                                    className="text-paragraph-sm"
+                                    style={{ color: 'var(--text-disabled)' }}
+                                >
+                                    {setLogs.length} sets &bull; same weight
+                                </span>
+                                <button
+                                    onClick={() => setShowPerSet(true)}
+                                    className="text-cta-xs"
+                                    style={{
+                                        textTransform: 'uppercase',
+                                        letterSpacing: '0.05em',
+                                        color: 'var(--text-cta)',
+                                        textDecoration: 'underline',
+                                        textUnderlineOffset: '3px',
+                                    }}
+                                >
+                                    Vary Sets
+                                </button>
+                            </div>
+                        </>
+                    )}
+
+                    {/* Per-Set Inputs (expanded) */}
+                    {canLogSets && showPerSet && (
                         <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>
                             {/* Column headers */}
                             <div style={{
                                 display: 'grid',
-                                gridTemplateColumns: hasWeight ? 'auto 1fr 1fr auto' : 'auto 1fr auto',
+                                gridTemplateColumns: hasWeight ? '32px minmax(0, 1fr) minmax(0, 1fr) 28px' : '32px minmax(0, 1fr) 28px',
                                 gap: 'var(--spacing-200)',
                                 alignItems: 'center',
                             }}>
                                 <span
                                     className="text-label-xs"
-                                    style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)', minWidth: 40 }}
+                                    style={{ textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-disabled)' }}
                                 >
                                     Set
                                 </span>
@@ -362,8 +488,7 @@ export const ActiveExerciseCard = ({
                                 >
                                     Reps
                                 </span>
-                                {/* Spacer for remove button column */}
-                                <span style={{ width: 28 }} />
+                                <span />
                             </div>
 
                             {/* Set rows */}
@@ -372,14 +497,14 @@ export const ActiveExerciseCard = ({
                                     key={set.setNumber}
                                     style={{
                                         display: 'grid',
-                                        gridTemplateColumns: hasWeight ? 'auto 1fr 1fr auto' : 'auto 1fr auto',
+                                        gridTemplateColumns: hasWeight ? '32px minmax(0, 1fr) minmax(0, 1fr) 28px' : '32px minmax(0, 1fr) 28px',
                                         gap: 'var(--spacing-200)',
                                         alignItems: 'center',
                                     }}
                                 >
                                     <span
                                         className="text-label-xs"
-                                        style={{ fontWeight: 'bold', textTransform: 'uppercase', color: 'var(--text-disabled)', minWidth: 40 }}
+                                        style={{ fontWeight: 'bold', textTransform: 'uppercase', color: 'var(--text-disabled)' }}
                                     >
                                         {set.setNumber}
                                     </span>
@@ -417,29 +542,43 @@ export const ActiveExerciseCard = ({
                                 </div>
                             ))}
 
-                            {/* Add set button */}
-                            <button
-                                onClick={handleAddSet}
-                                className="text-cta-xs"
-                                style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: 'var(--spacing-100)',
-                                    textTransform: 'uppercase',
-                                    letterSpacing: '0.05em',
-                                    color: 'var(--text-cta)',
-                                    paddingTop: 'var(--spacing-100)',
-                                }}
-                            >
-                                <Plus size={14} />
-                                Add Set
-                            </button>
+                            {/* Add set + collapse row */}
+                            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                <button
+                                    onClick={handleAddSet}
+                                    className="text-cta-xs"
+                                    style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 'var(--spacing-100)',
+                                        textTransform: 'uppercase',
+                                        letterSpacing: '0.05em',
+                                        color: 'var(--text-cta)',
+                                        paddingTop: 'var(--spacing-100)',
+                                    }}
+                                >
+                                    <Plus size={14} />
+                                    Add Set
+                                </button>
+                                <button
+                                    onClick={() => setShowPerSet(false)}
+                                    className="text-cta-xs"
+                                    style={{
+                                        textTransform: 'uppercase',
+                                        letterSpacing: '0.05em',
+                                        color: 'var(--text-disabled)',
+                                        paddingTop: 'var(--spacing-100)',
+                                    }}
+                                >
+                                    Collapse
+                                </button>
+                            </div>
                         </div>
                     )}
 
                     {/* Legacy single Weight / Reps Inputs (non per-set exercises) */}
-                    {showInputs && !showPerSetInputs && (
-                        <div style={hasWeight ? { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--spacing-300)' } : undefined}>
+                    {showInputs && !canLogSets && (
+                        <div style={hasWeight ? { display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)', gap: 'var(--spacing-300)' } : undefined}>
                             {hasWeight && (
                                 <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-200)' }}>
                                     <label
@@ -469,6 +608,11 @@ export const ActiveExerciseCard = ({
                                 />
                             </div>
                         </div>
+                    )}
+
+                    {/* Rest Timer Button */}
+                    {showRestButton && (
+                        <RestButton restLabel={exercise.rest!} onStart={() => onRestStart!(restSeconds)} />
                     )}
 
                     {/* Notes */}

--- a/src/components/workout/CircuitRenderer.tsx
+++ b/src/components/workout/CircuitRenderer.tsx
@@ -1,9 +1,11 @@
-import { Exercise } from "@/types/workout";
+import { Exercise, ExerciseSetData } from "@/types/workout";
 import { CircuitCard } from "./StructureCards";
 
 interface CircuitRendererProps {
     exercises: Exercise[];
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
+    onSetLog?: (id: string, data: ExerciseSetData) => void;
+    onRestStart?: (restSeconds: number) => void;
     sectionType: string;
     structure: NonNullable<Exercise['structure']>;
 }
@@ -12,6 +14,8 @@ interface CircuitRendererProps {
 export const CircuitRenderer = ({
     exercises,
     onLog,
+    onSetLog,
+    onRestStart,
     sectionType,
     structure,
 }: CircuitRendererProps) => {
@@ -19,6 +23,8 @@ export const CircuitRenderer = ({
         <CircuitCard
             exercises={exercises}
             onLog={onLog}
+            onSetLog={onSetLog}
+            onRestStart={onRestStart}
             sectionType={sectionType}
             sectionName={sectionType.replace('_', ' ')}
             structure={structure}

--- a/src/components/workout/RestTimerBar.tsx
+++ b/src/components/workout/RestTimerBar.tsx
@@ -5,6 +5,8 @@ interface RestTimerBarProps {
   remainingSeconds: number;
   totalSeconds: number;
   onDismiss: () => void;
+  /** Render inline (no fixed positioning). For gallery/preview use. */
+  inline?: boolean;
 }
 
 function formatCountdown(seconds: number): string {
@@ -14,9 +16,89 @@ function formatCountdown(seconds: number): string {
   return `${s}`;
 }
 
-export function RestTimerBar({ remainingSeconds, totalSeconds, onDismiss }: RestTimerBarProps) {
+export function RestTimerBar({ remainingSeconds, totalSeconds, onDismiss, inline }: RestTimerBarProps) {
   const isLow = remainingSeconds <= 5;
   const progress = totalSeconds > 0 ? ((totalSeconds - remainingSeconds) / totalSeconds) * 100 : 0;
+  const textColor = isLow ? 'var(--text-timer-low)' : 'var(--text-timer)';
+
+  const bar = (
+    <ChamferedFrame
+      cornerSize="sm"
+      surfaceColor={isLow ? 'var(--surface-timer-low)' : 'var(--surface-timer)'}
+      borderColor={isLow ? 'var(--border-timer-low)' : 'var(--border-timer)'}
+      hasLeftBorder
+    >
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--spacing-300)',
+        padding: 'var(--spacing-200) var(--spacing-400)',
+      }}>
+        <span
+          className="text-label-xs"
+          style={{
+            textTransform: 'uppercase',
+            letterSpacing: '0.1em',
+            fontWeight: 'bold',
+            color: textColor,
+            flexShrink: 0,
+          }}
+        >
+          Rest
+        </span>
+
+        <div style={{
+          flex: 1,
+          height: 4,
+          backgroundColor: isLow
+            ? 'color-mix(in srgb, var(--text-timer-low) 20%, transparent)'
+            : 'color-mix(in srgb, var(--text-timer) 20%, transparent)',
+          position: 'relative',
+          overflow: 'hidden',
+        }}>
+          <div style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            height: '100%',
+            width: `${progress}%`,
+            backgroundColor: textColor,
+            transition: 'width 0.25s linear',
+          }} />
+        </div>
+
+        <span
+          className="text-time-lg"
+          style={{
+            fontWeight: 'bold',
+            color: textColor,
+            minWidth: 40,
+            textAlign: 'right',
+            flexShrink: 0,
+          }}
+        >
+          {formatCountdown(remainingSeconds)}
+        </span>
+
+        <button
+          onClick={onDismiss}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 28,
+            height: 28,
+            flexShrink: 0,
+            color: textColor,
+          }}
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </ChamferedFrame>
+  );
+
+  if (inline) return bar;
 
   return (
     <div style={{
@@ -30,80 +112,7 @@ export function RestTimerBar({ remainingSeconds, totalSeconds, onDismiss }: Rest
       padding: '0 var(--spacing-400)',
     }}>
       <div style={{ maxWidth: '28rem', width: '100%' }}>
-        <ChamferedFrame
-          cornerSize="sm"
-          surfaceColor={isLow ? 'var(--surface-timer-low)' : 'var(--surface-timer)'}
-          borderColor={isLow ? 'var(--border-timer-low)' : 'var(--border-timer)'}
-          hasLeftBorder
-        >
-          <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--spacing-300)',
-            padding: 'var(--spacing-200) var(--spacing-400)',
-          }}>
-            <span
-              className="text-label-xs"
-              style={{
-                textTransform: 'uppercase',
-                letterSpacing: '0.1em',
-                fontWeight: 'bold',
-                color: isLow ? 'var(--text-timer-low)' : 'var(--text-disabled)',
-                flexShrink: 0,
-              }}
-            >
-              Rest
-            </span>
-
-            <div style={{
-              flex: 1,
-              height: 4,
-              backgroundColor: isLow
-                ? 'color-mix(in srgb, var(--text-timer-low) 20%, transparent)'
-                : 'color-mix(in srgb, var(--text-timer) 20%, transparent)',
-              position: 'relative',
-              overflow: 'hidden',
-            }}>
-              <div style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                height: '100%',
-                width: `${progress}%`,
-                backgroundColor: isLow ? 'var(--text-timer-low)' : 'var(--text-timer)',
-                transition: 'width 0.25s linear',
-              }} />
-            </div>
-
-            <span
-              className="text-time-lg glow-emissive"
-              style={{
-                fontWeight: 'bold',
-                color: isLow ? 'var(--text-timer-low)' : 'var(--text-timer)',
-                minWidth: 40,
-                textAlign: 'right',
-                flexShrink: 0,
-              }}
-            >
-              {formatCountdown(remainingSeconds)}
-            </span>
-
-            <button
-              onClick={onDismiss}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: 28,
-                height: 28,
-                flexShrink: 0,
-                color: isLow ? 'var(--text-timer-low)' : 'var(--text-disabled)',
-              }}
-            >
-              <X size={16} />
-            </button>
-          </div>
-        </ChamferedFrame>
+        {bar}
       </div>
     </div>
   );

--- a/src/components/workout/RestTimerBar.tsx
+++ b/src/components/workout/RestTimerBar.tsx
@@ -1,0 +1,110 @@
+import { X } from '@/components/icons';
+import { ChamferedFrame } from '@/components/ChamferedFrame';
+
+interface RestTimerBarProps {
+  remainingSeconds: number;
+  totalSeconds: number;
+  onDismiss: () => void;
+}
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m > 0) return `${m}:${s.toString().padStart(2, '0')}`;
+  return `${s}`;
+}
+
+export function RestTimerBar({ remainingSeconds, totalSeconds, onDismiss }: RestTimerBarProps) {
+  const isLow = remainingSeconds <= 5;
+  const progress = totalSeconds > 0 ? ((totalSeconds - remainingSeconds) / totalSeconds) * 100 : 0;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: 80,
+      left: 0,
+      right: 0,
+      zIndex: 45,
+      display: 'flex',
+      justifyContent: 'center',
+      padding: '0 var(--spacing-400)',
+    }}>
+      <div style={{ maxWidth: '28rem', width: '100%' }}>
+        <ChamferedFrame
+          cornerSize="sm"
+          surfaceColor={isLow ? 'var(--surface-timer-low)' : 'var(--surface-timer)'}
+          borderColor={isLow ? 'var(--border-timer-low)' : 'var(--border-timer)'}
+          hasLeftBorder
+        >
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--spacing-300)',
+            padding: 'var(--spacing-200) var(--spacing-400)',
+          }}>
+            <span
+              className="text-label-xs"
+              style={{
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                fontWeight: 'bold',
+                color: isLow ? 'var(--text-timer-low)' : 'var(--text-disabled)',
+                flexShrink: 0,
+              }}
+            >
+              Rest
+            </span>
+
+            <div style={{
+              flex: 1,
+              height: 4,
+              backgroundColor: isLow
+                ? 'color-mix(in srgb, var(--text-timer-low) 20%, transparent)'
+                : 'color-mix(in srgb, var(--text-timer) 20%, transparent)',
+              position: 'relative',
+              overflow: 'hidden',
+            }}>
+              <div style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                height: '100%',
+                width: `${progress}%`,
+                backgroundColor: isLow ? 'var(--text-timer-low)' : 'var(--text-timer)',
+                transition: 'width 0.25s linear',
+              }} />
+            </div>
+
+            <span
+              className="text-time-lg glow-emissive"
+              style={{
+                fontWeight: 'bold',
+                color: isLow ? 'var(--text-timer-low)' : 'var(--text-timer)',
+                minWidth: 40,
+                textAlign: 'right',
+                flexShrink: 0,
+              }}
+            >
+              {formatCountdown(remainingSeconds)}
+            </span>
+
+            <button
+              onClick={onDismiss}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 28,
+                height: 28,
+                flexShrink: 0,
+                color: isLow ? 'var(--text-timer-low)' : 'var(--text-disabled)',
+              }}
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </ChamferedFrame>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workout/SectionRenderer.tsx
+++ b/src/components/workout/SectionRenderer.tsx
@@ -22,6 +22,8 @@ interface SectionRendererProps {
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
     /** Called with per-set data for exercises that use set-by-set logging */
     onSetLog?: (id: string, data: ExerciseSetData) => void;
+    /** Called when user taps Rest button — triggers rest timer */
+    onRestStart?: (restSeconds: number) => void;
     /** Called when a timed section completes with structure-level result data */
     onStructureResult?: (sectionId: string, data: StructureResultData) => void;
 }
@@ -84,6 +86,7 @@ export const SectionRenderer = ({
     section,
     onLog,
     onSetLog,
+    onRestStart,
     onStructureResult,
 }: SectionRendererProps) => {
 
@@ -131,6 +134,7 @@ export const SectionRenderer = ({
                                 exercise={exercise}
                                 onLog={onLog}
                                 onSetLog={onSetLog}
+                                onRestStart={onRestStart}
                                 sectionType={section.type}
                                 bare
                             />
@@ -172,6 +176,7 @@ export const SectionRenderer = ({
                                     exercises={group.exercises}
                                     onLog={onLog}
                                     onSetLog={onSetLog}
+                                    onRestStart={onRestStart}
                                     sectionType={section.type}
                                     structure={group.structure}
                                 />
@@ -182,6 +187,8 @@ export const SectionRenderer = ({
                                     key={`group-${idx}`}
                                     exercises={group.exercises}
                                     onLog={onLog}
+                                    onSetLog={onSetLog}
+                                    onRestStart={onRestStart}
                                     sectionType={section.type}
                                     structure={group.structure}
                                 />

--- a/src/components/workout/StructureCards.tsx
+++ b/src/components/workout/StructureCards.tsx
@@ -1,11 +1,12 @@
 import { ExerciseStructure, Exercise, ExerciseSetData } from "@/types/workout";
-import { ActiveExerciseCard } from "./ActiveExerciseCard";
+import { ActiveExerciseCard, RestButton } from "./ActiveExerciseCard";
 import { Card } from "../Card";
 
 interface StructureCardProps {
     exercises: Exercise[];
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
     onSetLog?: (id: string, data: ExerciseSetData) => void;
+    onRestStart?: (restSeconds: number) => void;
     sectionType?: string;
     sectionName?: string;
     structure: ExerciseStructure;
@@ -18,7 +19,14 @@ const hasRest = (rest?: string): boolean => {
     return cleaned !== '0s' && cleaned !== '0' && cleaned !== '';
 };
 
-export const SupersetCard = ({ exercises, onLog, onSetLog, sectionType }: StructureCardProps) => {
+/** Parse rest string to seconds */
+const parseRestSeconds = (rest?: string): number => {
+    if (!rest) return 0;
+    const num = parseInt(rest);
+    return isNaN(num) ? 0 : num;
+};
+
+export const SupersetCard = ({ exercises, onLog, onSetLog, onRestStart, sectionType }: StructureCardProps) => {
     // Get the shared rest from the last exercise
     const lastExercise = exercises[exercises.length - 1];
     const pairRest = hasRest(lastExercise?.rest) ? lastExercise.rest : null;
@@ -56,22 +64,17 @@ export const SupersetCard = ({ exercises, onLog, onSetLog, sectionType }: Struct
                     ))}
                 </div>
             </div>
-            {/* Consolidated rest after pair */}
-            {pairRest && (
-                <div style={{ padding: 'var(--spacing-100) var(--spacing-400) var(--spacing-300)' }}>
-                    <span
-                        className="text-label-xs"
-                        style={{ textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--text-paragraph)' }}
-                    >
-                        Rest: {pairRest} after both
-                    </span>
+            {/* Rest timer button after pair */}
+            {pairRest && onRestStart && (
+                <div style={{ padding: '0 var(--spacing-400) var(--spacing-300)' }}>
+                    <RestButton restLabel={pairRest} onStart={() => onRestStart(parseRestSeconds(pairRest))} />
                 </div>
             )}
         </Card>
     );
 };
 
-export const CircuitCard = ({ exercises, onLog, sectionType, structure }: StructureCardProps) => {
+export const CircuitCard = ({ exercises, onLog, onSetLog, onRestStart, sectionType, structure }: StructureCardProps) => {
     const rounds = 'rounds' in structure ? structure.rounds : undefined;
 
     // Get round rest from the last exercise
@@ -112,6 +115,7 @@ export const CircuitCard = ({ exercises, onLog, sectionType, structure }: Struct
                         key={exercise.id}
                         exercise={exercise}
                         onLog={onLog}
+                        onSetLog={onSetLog}
                         sectionType={sectionType}
                         bare
                         pairLabel={`${i + 1}.`}
@@ -119,15 +123,10 @@ export const CircuitCard = ({ exercises, onLog, sectionType, structure }: Struct
                 ))}
             </div>
 
-            {/* Consolidated round rest */}
-            {roundRest && (
-                <div style={{ padding: 'var(--spacing-100) var(--spacing-400) var(--spacing-300)' }}>
-                    <span
-                        className="text-label-xs"
-                        style={{ textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--text-paragraph)' }}
-                    >
-                        {roundRest} rest between rounds
-                    </span>
+            {/* Rest timer button between rounds */}
+            {roundRest && onRestStart && (
+                <div style={{ padding: '0 var(--spacing-400) var(--spacing-300)' }}>
+                    <RestButton restLabel={roundRest} onStart={() => onRestStart(parseRestSeconds(roundRest))} />
                 </div>
             )}
         </Card>

--- a/src/components/workout/SupersetRenderer.tsx
+++ b/src/components/workout/SupersetRenderer.tsx
@@ -5,6 +5,7 @@ interface SupersetRendererProps {
     exercises: Exercise[];
     onLog: (id: string, data: { weight?: string; reps?: string; notes?: string }) => void;
     onSetLog?: (id: string, data: ExerciseSetData) => void;
+    onRestStart?: (restSeconds: number) => void;
     sectionType: string;
     structure: NonNullable<Exercise['structure']>;
 }
@@ -14,6 +15,7 @@ export const SupersetRenderer = ({
     exercises,
     onLog,
     onSetLog,
+    onRestStart,
     sectionType,
     structure,
 }: SupersetRendererProps) => {
@@ -22,6 +24,7 @@ export const SupersetRenderer = ({
             exercises={exercises}
             onLog={onLog}
             onSetLog={onSetLog}
+            onRestStart={onRestStart}
             sectionType={sectionType}
             sectionName={sectionType.replace('_', ' ')}
             structure={structure}

--- a/src/hooks/useRestTimer.ts
+++ b/src/hooks/useRestTimer.ts
@@ -1,0 +1,79 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+interface RestTimerState {
+  isActive: boolean;
+  remainingSeconds: number;
+  totalSeconds: number;
+}
+
+/** Play a two-tone completion sound via Web Audio API */
+function playCompletionSound() {
+  try {
+    const ctx = new AudioContext();
+    const playTone = (freq: number, startTime: number, duration: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.frequency.value = freq;
+      osc.type = 'sine';
+      gain.gain.setValueAtTime(0.15, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
+      osc.start(startTime);
+      osc.stop(startTime + duration);
+    };
+    const now = ctx.currentTime;
+    playTone(880, now, 0.15);
+    playTone(1100, now + 0.15, 0.2);
+  } catch {
+    // Audio not available — silent fallback
+  }
+}
+
+export function useRestTimer() {
+  const [timer, setTimer] = useState<RestTimerState>({
+    isActive: false,
+    remainingSeconds: 0,
+    totalSeconds: 0,
+  });
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const endTimeRef = useRef<number>(0);
+
+  const clearTimer = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const dismissTimer = useCallback(() => {
+    clearTimer();
+    setTimer({ isActive: false, remainingSeconds: 0, totalSeconds: 0 });
+  }, [clearTimer]);
+
+  const startTimer = useCallback((seconds: number) => {
+    clearTimer();
+    endTimeRef.current = Date.now() + seconds * 1000;
+
+    setTimer({ isActive: true, remainingSeconds: seconds, totalSeconds: seconds });
+
+    intervalRef.current = setInterval(() => {
+      const remaining = Math.max(0, Math.ceil((endTimeRef.current - Date.now()) / 1000));
+      if (remaining <= 0) {
+        clearTimer();
+        playCompletionSound();
+        // Auto-dismiss after 2 seconds
+        setTimeout(() => {
+          setTimer(prev => prev.remainingSeconds <= 0 ? { isActive: false, remainingSeconds: 0, totalSeconds: 0 } : prev);
+        }, 2000);
+      }
+      setTimer(prev => ({ ...prev, remainingSeconds: remaining }));
+    }, 250);
+  }, [clearTimer]);
+
+  // Cleanup on unmount
+  useEffect(() => clearTimer, [clearTimer]);
+
+  return { timer, startTimer, dismissTimer };
+}

--- a/src/hooks/useWorkoutSession.ts
+++ b/src/hooks/useWorkoutSession.ts
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { toast } from "@/components/ui/sonner";
 import { logger } from "@/lib/logger";
 import {
@@ -33,17 +33,28 @@ export const useWorkoutSession = ({
     const [isRepeat, setIsRepeat] = useState(false);
     const [repeatSavedWorkoutId, setRepeatSavedWorkoutId] = useState<string | null>(null);
 
+    // Deferred navigation: wait for workoutNotes state to commit before navigating
+    const finishCallback = useRef<(() => void) | null>(null);
+
+    useEffect(() => {
+        if (workoutNotes && finishCallback.current) {
+            const cb = finishCallback.current;
+            finishCallback.current = null;
+            cb();
+        }
+    }, [workoutNotes]);
+
     const handleStartWorkout = (onSuccess?: () => void) => {
         workoutStartTime.current = Date.now();
         if (onSuccess) onSuccess();
     };
 
-    const handleFinishWorkout = (notes: WorkoutNotes, onSuccess?: () => void) => {
+    const handleFinishWorkout = useCallback((notes: WorkoutNotes, onSuccess?: () => void) => {
         const elapsed = Math.floor((Date.now() - workoutStartTime.current) / 1000);
+        finishCallback.current = onSuccess || null;
         setTotalTime(elapsed);
         setWorkoutNotes(notes);
-        if (onSuccess) onSuccess();
-    };
+    }, []);
 
     const handleFinishSession = async (mood: number | null, sessionNotes: string, onSuccess?: () => void) => {
         // Calculate duration in minutes

--- a/src/index.css
+++ b/src/index.css
@@ -413,7 +413,7 @@ ul, ol {
     --text-cta: var(--color-blue-100);
     --text-cta-hover: var(--color-blue-500);
     --text-on-cta: var(--color-orange-100);
-    --text-timer: var(--color-green-400);
+    --text-timer: var(--color-green-900);
     --text-timer-low: var(--color-red-900);
     --text-label-info: var(--color-blue-100);
     --text-label-selected: var(--color-green-500);

--- a/src/layouts/WorkoutLayout.tsx
+++ b/src/layouts/WorkoutLayout.tsx
@@ -10,26 +10,24 @@ interface WorkoutLayoutProps {
 
 export const WorkoutLayout = ({ header, footer, children, onTouchStart, onTouchEnd }: WorkoutLayoutProps) => {
   return (
-    <>
-      <div
-        className="grain-overlay"
-        style={{ minHeight: '100vh' }}
-        onTouchStart={onTouchStart}
-        onTouchEnd={onTouchEnd}
-      >
-        {header}
-        <div style={{
-          maxWidth: '28rem',
-          margin: '0 auto',
-          paddingTop: 'var(--spacing-1100)',
-          paddingBottom: footer ? 'var(--spacing-1300)' : 'var(--spacing-700)',
-        }}>
-          <div style={{ padding: '0 var(--spacing-400)' }}>
-            {children}
-          </div>
+    <div
+      className="grain-overlay"
+      style={{ minHeight: '100vh' }}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      {header}
+      <div style={{
+        maxWidth: '28rem',
+        margin: '0 auto',
+        paddingTop: 'var(--spacing-1100)',
+        paddingBottom: footer ? 'var(--spacing-1300)' : 'var(--spacing-700)',
+      }}>
+        <div style={{ padding: '0 var(--spacing-400)' }}>
+          {children}
         </div>
       </div>
       {footer}
-    </>
+    </div>
   );
 };

--- a/src/layouts/WorkoutLayout.tsx
+++ b/src/layouts/WorkoutLayout.tsx
@@ -10,29 +10,26 @@ interface WorkoutLayoutProps {
 
 export const WorkoutLayout = ({ header, footer, children, onTouchStart, onTouchEnd }: WorkoutLayoutProps) => {
   return (
-    <div
-      className="grain-overlay"
-      style={{
-        minHeight: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        paddingBottom: '7rem',
-        position: 'relative',
-      }}
-      onTouchStart={onTouchStart}
-      onTouchEnd={onTouchEnd}
-    >
-      {header}
-      <div style={{
-        maxWidth: '28rem',
-        margin: '0 auto',
-        width: '100%',
-        padding: '0 var(--spacing-400)',
-        paddingTop: 'var(--spacing-1100)',
-      }}>
-        {children}
+    <>
+      <div
+        className="grain-overlay"
+        style={{ minHeight: '100vh' }}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+      >
+        {header}
+        <div style={{
+          maxWidth: '28rem',
+          margin: '0 auto',
+          paddingTop: 'var(--spacing-1100)',
+          paddingBottom: footer ? 'var(--spacing-1300)' : 'var(--spacing-700)',
+        }}>
+          <div style={{ padding: '0 var(--spacing-400)' }}>
+            {children}
+          </div>
+        </div>
       </div>
       {footer}
-    </div>
+    </>
   );
 };

--- a/src/pages/ComponentGallery.tsx
+++ b/src/pages/ComponentGallery.tsx
@@ -58,6 +58,10 @@ import { ErrorState } from "@/components/ErrorState";
 import { EmptyState } from "@/components/EmptyState";
 import { ActionButton } from "@/components/ActionButton";
 import { ActionCard } from "@/components/ActionCard";
+
+// Workout components
+import { ActiveExerciseCard } from "@/components/workout/ActiveExerciseCard";
+import { RestTimerBar } from "@/components/workout/RestTimerBar";
 import { Card as ChamferedCard } from "@/components/Card";
 import { CTAButton } from "@/components/CTAButton";
 import { RadioButton } from "@/components/RadioButton";
@@ -97,6 +101,8 @@ export const ComponentGallery = () => {
   const [panelTab, setPanelTab] = useState<'one' | 'two'>('one');
   const [filterAnchor, setFilterAnchor] = useState<'ALL' | 'squat' | 'hinge'>('ALL');
   const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [restTimerRemaining, setRestTimerRemaining] = useState(45);
+  const [restTimerActive, setRestTimerActive] = useState(false);
 
   const sampleFilterOptions: FilterOption<'ALL' | 'squat' | 'hinge'>[] = [
     { value: 'ALL', label: 'All Anchors' },
@@ -870,6 +876,71 @@ export const ComponentGallery = () => {
                 <ActionCard cornerSize="lg">
                   Large Chamfer
                 </ActionCard>
+              </Subsection>
+            </div>
+          </Section>
+
+          {/* ─── WORKOUT COMPONENTS ─── */}
+          <Section title="Workout — ActiveExerciseCard (Per-Set)">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-400)' }}>
+              <Subsection label="Weighted exercise (barbell) — per-set mode">
+                <ActiveExerciseCard
+                  exercise={{
+                    id: 'demo-back-squat',
+                    name: 'Back Squat',
+                    sets: 4,
+                    reps: '6',
+                    effort: '75%',
+                    rest: '120s',
+                    equipment: 'barbell',
+                    coachingCues: ['Brace hard before descent', 'Drive knees out over toes'],
+                    regression: 'Goblet Squat',
+                    lastWeight: '185',
+                    lastSetData: [
+                      { setNumber: 1, weight: 185, reps: 6 },
+                      { setNumber: 2, weight: 185, reps: 6 },
+                      { setNumber: 3, weight: 185, reps: 5 },
+                      { setNumber: 4, weight: 175, reps: 6 },
+                    ],
+                  }}
+                  onLog={() => {}}
+                  onSetLog={() => {}}
+                  onRestStart={(s) => { setRestTimerRemaining(s); setRestTimerActive(true); }}
+                  sectionType="primary_lift"
+                  defaultExpanded
+                />
+              </Subsection>
+              <Subsection label="Bodyweight exercise (no weight column)">
+                <ActiveExerciseCard
+                  exercise={{
+                    id: 'demo-pull-ups',
+                    name: 'Pull-Ups',
+                    sets: 3,
+                    reps: '8',
+                    rest: '90s',
+                    equipment: 'bodyweight',
+                    coachingCues: ['Full dead hang at bottom', 'Chin over bar'],
+                  }}
+                  onLog={() => {}}
+                  onSetLog={() => {}}
+                  onRestStart={(s) => { setRestTimerRemaining(s); setRestTimerActive(true); }}
+                  sectionType="accessory"
+                  defaultExpanded
+                />
+              </Subsection>
+            </div>
+          </Section>
+
+          <Section title="Workout — RestTimerBar">
+            <p className="text-paragraph-sm" style={{ color: 'var(--text-disabled)', marginBottom: 'var(--spacing-300)' }}>
+              In-app this is fixed to the bottom. Tap a Rest button on the cards above to trigger the live timer.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-400)' }}>
+              <Subsection label="Normal state (45s remaining)">
+                <RestTimerBar remainingSeconds={45} totalSeconds={90} onDismiss={() => {}} inline />
+              </Subsection>
+              <Subsection label="Low time state (≤5s)">
+                <RestTimerBar remainingSeconds={3} totalSeconds={90} onDismiss={() => {}} inline />
               </Subsection>
             </div>
           </Section>

--- a/src/pages/WorkoutScreen.tsx
+++ b/src/pages/WorkoutScreen.tsx
@@ -5,7 +5,9 @@ import { PageHeader } from "@/components/PageHeader";
 import { WorkoutLayout } from "@/layouts";
 import { SectionRenderer, StructureResultData } from "@/components/workout/SectionRenderer";
 import { ProgressTracker } from "@/components/workout/ProgressTracker";
+import { RestTimerBar } from "@/components/workout/RestTimerBar";
 import { useWorkoutFlowContext } from "@/contexts/WorkoutFlowContext";
+import { useRestTimer } from "@/hooks/useRestTimer";
 import type { ExerciseSetData } from "@/types/workout";
 
 type LoggedExerciseData = Record<string, { weight?: string; reps?: string; notes?: string }>;
@@ -17,6 +19,7 @@ export const WorkoutScreen = () => {
   const [loggedData, setLoggedData] = useState<LoggedExerciseData>({});
   const [setLogData, setSetLogData] = useState<Record<string, ExerciseSetData>>({});
   const [structureResults, setStructureResults] = useState<Record<string, StructureResultData>>({});
+  const { timer, startTimer, dismissTimer } = useRestTimer();
 
   const touchStartX = useRef<number | null>(null);
   const startTime = useRef(Date.now());
@@ -50,11 +53,13 @@ export const WorkoutScreen = () => {
 
   const handleBack = () => {
     if (currentSectionIndex > 0) {
+      dismissTimer();
       setCurrentSectionIndex((prev) => prev - 1);
     }
   };
 
   const handleNext = () => {
+    dismissTimer();
     if (isLastSection) {
       handleFinishWorkout({
         loggedData,
@@ -78,6 +83,10 @@ export const WorkoutScreen = () => {
   const handleSetLog = useCallback((id: string, data: ExerciseSetData) => {
     setSetLogData(prev => ({ ...prev, [id]: data }));
   }, []);
+
+  const handleRestStart = useCallback((restSeconds: number) => {
+    startTimer(restSeconds);
+  }, [startTimer]);
 
   const handleStructureResult = useCallback((sectionId: string, data: StructureResultData) => {
     setStructureResults(prev => ({ ...prev, [sectionId]: data }));
@@ -121,8 +130,17 @@ export const WorkoutScreen = () => {
         section={currentSection}
         onLog={handleLog}
         onSetLog={handleSetLog}
+        onRestStart={handleRestStart}
         onStructureResult={handleStructureResult}
       />
+
+      {timer.isActive && (
+        <RestTimerBar
+          remainingSeconds={timer.remainingSeconds}
+          totalSeconds={timer.totalSeconds}
+          onDismiss={dismissTimer}
+        />
+      )}
     </WorkoutLayout>
   );
 };

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -11,6 +11,7 @@ export interface SetLog {
   weightUnit?: 'lbs' | 'kg';
   reps?: number;
   rpe?: number;
+  completed?: boolean;
 }
 
 // Aggregated set data for an exercise

--- a/supabase/functions/generate-workout/index.ts
+++ b/supabase/functions/generate-workout/index.ts
@@ -94,6 +94,67 @@ interface RecentWorkout {
 // System prompt imported from ./prompt.ts
 
 // ============================================
+// ANCHOR-AWARE EXERCISE FILTERING
+// ============================================
+
+// For balanced programming, include exercises from the contrasting anchor
+const CONTRASTING_ANCHORS: Record<string, string[]> = {
+  squat: ['pull'],   // lower push ↔ upper pull
+  hinge: ['press'],  // posterior ↔ anterior press
+  press: ['pull'],   // push ↔ pull
+  pull: ['press'],   // pull ↔ push
+  power: [],         // full-body — self-contained
+};
+
+// Roles that pass regardless of anchor (warmup/cooldown/conditioning universals)
+const ANCHOR_EXEMPT_ROLES = new Set([
+  'activation', 'mobility', 'conditioning', 'stability', 'cardio',
+]);
+
+// If anchor filtering produces fewer than this many exercises, skip it
+const ANCHOR_FILTER_MIN_THRESHOLD = 20;
+
+/**
+ * Filter exercises to only those relevant to the day's anchor + thematic needs.
+ * Reduces prompt size without losing workout quality.
+ *
+ * An exercise passes if ANY of:
+ *   (a) Its anchors array contains the day's anchor
+ *   (b) Its exercise_role is anchor-exempt (conditioning, mobility, etc.)
+ *   (c) Its anchors array contains a contrasting anchor for the day
+ */
+function filterByAnchor(
+  exercises: ExerciseDefinition[],
+  dayAnchor: string
+): ExerciseDefinition[] {
+  const contrastingAnchors = CONTRASTING_ANCHORS[dayAnchor] || [];
+
+  const filtered = exercises.filter((ex) => {
+    const exAnchors = ex.anchors || [];
+
+    // (a) Direct anchor match
+    if (exAnchors.includes(dayAnchor)) return true;
+
+    // (b) Role-exempt (warmup/cooldown/conditioning universals)
+    if (ex.exercise_role && ANCHOR_EXEMPT_ROLES.has(ex.exercise_role)) return true;
+
+    // (c) Contrasting anchor for balanced programming
+    if (contrastingAnchors.some((ca) => exAnchors.includes(ca))) return true;
+
+    return false;
+  });
+
+  // Safety net: if filtered list is too small, skip anchor filtering
+  if (filtered.length < ANCHOR_FILTER_MIN_THRESHOLD) {
+    console.log(`[Anchor Filter] Skipped: ${filtered.length} exercises below threshold (${ANCHOR_FILTER_MIN_THRESHOLD}). Using full list (${exercises.length}).`);
+    return exercises;
+  }
+
+  console.log(`[Anchor Filter] anchor=${dayAnchor}: ${exercises.length} → ${filtered.length} exercises`);
+  return filtered;
+}
+
+// ============================================
 // HELPER FUNCTIONS
 // ============================================
 
@@ -563,7 +624,7 @@ serve(async (req: Request) => {
 
     // Filter exercises: must have at least one equipment option available AND
     // at least one section that matches the user's enabled sections
-    const availableExercises = (exerciseDefinitions || []).filter((ex: any) => {
+    const equipmentFiltered = (exerciseDefinitions || []).filter((ex: any) => {
       const hasEquipment = (ex.equipment_options || []).some((eq: string) =>
         availableEquipment.has(eq)
       );
@@ -572,6 +633,12 @@ serve(async (req: Request) => {
       );
       return hasEquipment && hasSection;
     });
+
+    // Anchor-aware filtering: keep only exercises relevant to today's focus
+    const availableExercises = filterByAnchor(
+      equipmentFiltered as ExerciseDefinition[],
+      request.anchor
+    );
 
     const exerciseLibrary = new Set((exerciseDefinitions || []).map((e: any) => e.id));
 

--- a/supabase/migrations/00027_suggest_anchor_rpc.sql
+++ b/supabase/migrations/00027_suggest_anchor_rpc.sql
@@ -15,7 +15,7 @@ BEGIN
     SELECT ws.id AS session_id, ws.date
     FROM workout_sessions ws
     WHERE ws.user_id = p_user_id
-      AND ws.status = 'completed'
+      AND ws.completed_at IS NOT NULL
       AND ws.date >= (CURRENT_DATE - INTERVAL '7 days')
   ),
   exercise_muscles AS (
@@ -26,7 +26,7 @@ BEGIN
     FROM recent_sessions rs
     JOIN workout_sections wsec ON wsec.session_id = rs.session_id
     JOIN exercises ex ON ex.section_id = wsec.id
-    JOIN exercise_muscle_groups emg ON emg.exercise_id = ex.id
+    JOIN exercise_muscle_groups emg ON emg.exercise_id = ex.exercise_id
   ),
   region_mapping AS (
     SELECT

--- a/supabase/migrations/00030_workout_anatomy_schema.sql
+++ b/supabase/migrations/00030_workout_anatomy_schema.sql
@@ -323,7 +323,7 @@ BEGIN
     SELECT ws.id AS session_id, ws.date
     FROM workout_sessions ws
     WHERE ws.user_id = p_user_id
-      AND ws.status = 'completed'
+      AND ws.completed_at IS NOT NULL
       AND ws.date >= (CURRENT_DATE - INTERVAL '7 days')
   ),
   exercise_muscles AS (
@@ -334,7 +334,7 @@ BEGIN
     FROM recent_sessions rs
     JOIN workout_sections wsec ON wsec.session_id = rs.session_id
     JOIN exercises ex ON ex.section_id = wsec.id
-    JOIN exercise_muscle_groups emg ON emg.exercise_id = ex.id
+    JOIN exercise_muscle_groups emg ON emg.exercise_id = ex.exercise_id
   ),
   region_mapping AS (
     SELECT


### PR DESCRIPTION
## Summary
- **Anchor-aware exercise filtering**: Pre-filters exercise library by day's anchor before building the LLM prompt. Keeps direct matches, contrasting anchors (for balanced programming), and role-exempt exercises. Falls back to full list if filtered count < 20. Reduces prompt size → faster generation → better exercise selection.
- **Rest timer**: New `RestTimerBar` component + `useRestTimer` hook with progress bar, countdown, Web Audio completion sound, auto-dismiss. Replaces static "Rest: 90s" text with interactive buttons in supersets/circuits.
- **Per-set completion toggle**: Checkbox per set row, completed sets dim to 50% opacity.
- **ActiveExerciseCard grid tightened** for mobile (24px touch targets, fixed column widths).
- **Timer color fix**: `--text-timer` green-400 → green-900 (dark on green, matches selected chip style).
- **Migration bug fixes**: suggest_anchor RPC used wrong column and join.
- **Gallery examples** for ActiveExerciseCard and RestTimerBar.

## Test plan
- [ ] Generate a workout and verify exercises are relevant to the selected anchor
- [ ] Check generation edge function logs for `[Anchor Filter]` messages showing before/after counts
- [ ] Tap Rest button on an exercise — timer bar appears at bottom, counts down, plays sound, auto-dismisses
- [ ] In per-set mode, tap checkmarks to toggle set completion — row dims
- [ ] Verify grid columns align on narrow mobile viewport (375px)
- [ ] Visit `/dev/gallery` → scroll to Workout section → verify RestTimerBar renders inline with dark text on green
- [ ] Verify left border stroke is visible on timer bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)